### PR TITLE
Expand editor

### DIFF
--- a/amble_editor/src/main.rs
+++ b/amble_editor/src/main.rs
@@ -1,6 +1,6 @@
-use std::{collections::HashMap, io, time::Duration};
+use std::{io, time::Duration};
 
-use amble_engine::{Item, load_world};
+use amble_engine::{item::Item, load_world, npc::Npc, room::Room};
 use crossterm::{
     event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode},
     execute,
@@ -13,28 +13,28 @@ use ratatui::{
     style::{Color, Style},
     widgets::{Block, Borders, List, ListItem, Paragraph},
 };
-use uuid::Uuid;
 
-fn load_items_from_engine() -> anyhow::Result<HashMap<Uuid, Item>> {
-    let world = load_world()?;
-
-    Ok(world.items.clone())
+enum ViewMode {
+    Rooms,
+    Items,
+    Npcs,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Load items from engine
-    let item_map = load_items_from_engine()?;
-    let items: Vec<_> = item_map.values().collect();
-    let mut selected = 0;
+    // Load world data
+    let world = load_world()?;
 
-    // Setup terminal UI
+    let mut mode = ViewMode::Rooms;
+    let mut selected_room = 0usize;
+    let mut selected_item = 0usize;
+    let mut selected_npc = 0usize;
+
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    // Main event loop
     loop {
         terminal.draw(|f| {
             let chunks = Layout::default()
@@ -42,37 +42,112 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .constraints([Constraint::Length(30), Constraint::Min(10)].as_ref())
                 .split(f.size());
 
-            // Left sidebar: list of item names
-            let list_items: Vec<ListItem> = items.iter().map(|item| ListItem::new(item.name.as_str())).collect();
+            match mode {
+                ViewMode::Rooms => {
+                    let rooms: Vec<&Room> = world.rooms.values().collect();
+                    let list_items: Vec<ListItem> =
+                        rooms.iter().map(|room| ListItem::new(room.symbol.as_str())).collect();
+                    let list = List::new(list_items)
+                        .block(Block::default().title("Rooms").borders(Borders::ALL))
+                        .highlight_style(Style::default().fg(Color::Yellow));
+                    let mut state = ratatui::widgets::ListState::default();
+                    state.select(Some(selected_room));
+                    f.render_stateful_widget(list, chunks[0], &mut state);
 
-            let list = List::new(list_items)
-                .block(Block::default().title("Items").borders(Borders::ALL))
-                .highlight_style(Style::default().fg(Color::Yellow));
+                    let room = rooms[selected_room];
+                    let detail = format!(
+                        "Name: {}\nSymbol: {}\nUUID: {}\nVisited: {}\nDescription: {}\nLocation: {:?}",
+                        room.name, room.symbol, room.id, room.visited, room.base_description, room.location
+                    );
+                    let paragraph =
+                        Paragraph::new(detail).block(Block::default().title("Detail").borders(Borders::ALL));
+                    f.render_widget(paragraph, chunks[1]);
+                },
+                ViewMode::Items => {
+                    let items: Vec<&Item> = world.items.values().collect();
+                    let list_items: Vec<ListItem> =
+                        items.iter().map(|item| ListItem::new(item.symbol.as_str())).collect();
+                    let list = List::new(list_items)
+                        .block(Block::default().title("Items").borders(Borders::ALL))
+                        .highlight_style(Style::default().fg(Color::Yellow));
+                    let mut state = ratatui::widgets::ListState::default();
+                    state.select(Some(selected_item));
+                    f.render_stateful_widget(list, chunks[0], &mut state);
 
-            let mut state = ratatui::widgets::ListState::default();
-            state.select(Some(selected));
-            f.render_stateful_widget(list, chunks[0], &mut state);
+                    let item = items[selected_item];
+                    let detail = format!(
+                        "Name: {}\nSymbol: {}\nUUID: {}\nDescription: {}\nLocation: {:?}",
+                        item.name, item.symbol, item.id, item.description, item.location
+                    );
+                    let paragraph =
+                        Paragraph::new(detail).block(Block::default().title("Detail").borders(Borders::ALL));
+                    f.render_widget(paragraph, chunks[1]);
+                },
+                ViewMode::Npcs => {
+                    let npcs: Vec<&Npc> = world.npcs.values().collect();
+                    let list_items: Vec<ListItem> = npcs.iter().map(|npc| ListItem::new(npc.symbol.as_str())).collect();
+                    let list = List::new(list_items)
+                        .block(Block::default().title("NPCs").borders(Borders::ALL))
+                        .highlight_style(Style::default().fg(Color::Yellow));
+                    let mut state = ratatui::widgets::ListState::default();
+                    state.select(Some(selected_npc));
+                    f.render_stateful_widget(list, chunks[0], &mut state);
 
-            // Right panel: item detail
-            let detail = format!(
-                "Name: {}\nUUID: {}\nDescription: {}\nLocation: {:?}",
-                items[selected].name, items[selected].id, items[selected].description, items[selected].location
-            );
-
-            let paragraph = Paragraph::new(detail).block(Block::default().title("Detail").borders(Borders::ALL));
-            f.render_widget(paragraph, chunks[1]);
+                    let npc = npcs[selected_npc];
+                    let detail = format!(
+                        "Name: {}\nSymbol: {}\nUUID: {}\nMood: {:?}\nDescription: {}\nLocation: {:?}",
+                        npc.name, npc.symbol, npc.id, npc.mood, npc.description, npc.location
+                    );
+                    let paragraph =
+                        Paragraph::new(detail).block(Block::default().title("Detail").borders(Borders::ALL));
+                    f.render_widget(paragraph, chunks[1]);
+                },
+            }
         })?;
 
-        // Handle key input
         if event::poll(Duration::from_millis(200))? {
             if let Event::Key(key) = event::read()? {
                 match key.code {
                     KeyCode::Char('q') => break,
-                    KeyCode::Down => {
-                        selected = (selected + 1).min(items.len().saturating_sub(1));
+                    KeyCode::Char('r') => {
+                        mode = ViewMode::Rooms;
                     },
-                    KeyCode::Up => {
-                        selected = selected.saturating_sub(1);
+                    KeyCode::Char('i') => {
+                        mode = ViewMode::Items;
+                    },
+                    KeyCode::Char('n') => {
+                        mode = ViewMode::Npcs;
+                    },
+                    KeyCode::Down => match mode {
+                        ViewMode::Rooms => {
+                            let len = world.rooms.len();
+                            if len > 0 {
+                                selected_room = (selected_room + 1).min(len - 1);
+                            }
+                        },
+                        ViewMode::Items => {
+                            let len = world.items.len();
+                            if len > 0 {
+                                selected_item = (selected_item + 1).min(len - 1);
+                            }
+                        },
+                        ViewMode::Npcs => {
+                            let len = world.npcs.len();
+                            if len > 0 {
+                                selected_npc = (selected_npc + 1).min(len - 1);
+                            }
+                        },
+                    },
+                    KeyCode::Up => match mode {
+                        ViewMode::Rooms => {
+                            selected_room = selected_room.saturating_sub(1);
+                        },
+                        ViewMode::Items => {
+                            selected_item = selected_item.saturating_sub(1);
+                        },
+                        ViewMode::Npcs => {
+                            selected_npc = selected_npc.saturating_sub(1);
+                        },
                     },
                     _ => {},
                 }
@@ -80,10 +155,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Restore terminal state
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
     terminal.show_cursor()?;
-
     Ok(())
 }


### PR DESCRIPTION
## Summary
- add a simple terminal interface to browse rooms, items and NPCs
- use `.symbol` for the pick list and add hotkeys to swap lists

## Testing
- `cargo +nightly check --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68832b156d88832494e9872bb25a6a8e