### PR TITLE
Add editing mode to TUI

### DIFF
--- a/amble_editor/src/main.rs
+++ b/amble_editor/src/main.rs
@@ -10,11 +10,19 @@ use crossterm::{
 use ratatui::{
     Terminal,
     backend::CrosstermBackend,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
 };
+use uuid::Uuid;
+
+enum EditKind {
+    Room,
+    Item,
+    Npc,
+    Trigger,
+}
 
 enum ViewMode {
     Rooms,
@@ -33,6 +41,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut selected_item = 0usize;
     let mut selected_npc = 0usize;
     let mut selected_trigger = 0usize;
+    let mut editing: Option<EditKind> = None;
+    let mut input_buffer = String::new();
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -42,6 +52,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     loop {
         terminal.draw(|f| {
+            if let Some(kind) = &editing {
+                let size = f.size();
+                let area = Rect {
+                    x: 0,
+                    y: size.height.saturating_sub(3),
+                    width: size.width,
+                    height: 3,
+                };
+                let title = match kind {
+                    EditKind::Room => "Edit Room Name",
+                    EditKind::Item => "Edit Item Name",
+                    EditKind::Npc => "Edit NPC Name",
+                    EditKind::Trigger => "Edit Trigger Name",
+                };
+                let paragraph =
+                    Paragraph::new(input_buffer.as_str()).block(Block::default().title(title).borders(Borders::ALL));
+                f.render_widget(paragraph, area);
+                f.set_cursor(area.x + input_buffer.len() as u16 + 1, area.y + 1);
+                return;
+            }
+
             let sidebar_width = if matches!(mode, ViewMode::Triggers) { 40 } else { 30 };
             let chunks = Layout::default()
                 .direction(Direction::Horizontal)
@@ -50,9 +81,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             match mode {
                 ViewMode::Rooms => {
-                    let rooms: Vec<&Room> = world.rooms.values().collect();
-                    let list_items: Vec<ListItem> =
-                        rooms.iter().map(|room| ListItem::new(room.symbol.as_str())).collect();
+                    let mut rooms: Vec<(uuid::Uuid, &Room)> = world.rooms.iter().map(|(id, r)| (*id, r)).collect();
+                    rooms.sort_by_key(|(_, r)| r.symbol.clone());
+                    let list_items: Vec<ListItem> = rooms
+                        .iter()
+                        .map(|(_, room)| ListItem::new(room.symbol.as_str()))
+                        .collect();
                     let list = List::new(list_items)
                         .block(Block::default().title("Rooms").borders(Borders::ALL))
                         .highlight_style(Style::default().fg(Color::Yellow));
@@ -119,9 +153,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     f.render_widget(paragraph, chunks[1]);
                 },
                 ViewMode::Items => {
-                    let items: Vec<&Item> = world.items.values().collect();
-                    let list_items: Vec<ListItem> =
-                        items.iter().map(|item| ListItem::new(item.symbol.as_str())).collect();
+                    let mut items: Vec<(uuid::Uuid, &Item)> = world.items.iter().map(|(id, i)| (*id, i)).collect();
+                    items.sort_by_key(|(_, i)| i.symbol.clone());
+                    let list_items: Vec<ListItem> = items
+                        .iter()
+                        .map(|(_, item)| ListItem::new(item.symbol.as_str()))
+                        .collect();
                     let list = List::new(list_items)
                         .block(Block::default().title("Items").borders(Borders::ALL))
                         .highlight_style(Style::default().fg(Color::Yellow));
@@ -129,7 +166,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     state.select(Some(selected_item));
                     f.render_stateful_widget(list, chunks[0], &mut state);
 
-                    let item = items[selected_item];
+                    let (_, item) = items[selected_item];
                     let mut detail = vec![
                         Line::from(vec![
                             Span::styled("Name: ", Style::default().fg(Color::Blue)),
@@ -177,8 +214,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     f.render_widget(paragraph, chunks[1]);
                 },
                 ViewMode::Npcs => {
-                    let npcs: Vec<&Npc> = world.npcs.values().collect();
-                    let list_items: Vec<ListItem> = npcs.iter().map(|npc| ListItem::new(npc.symbol.as_str())).collect();
+                    let mut npcs: Vec<(uuid::Uuid, &Npc)> = world.npcs.iter().map(|(id, n)| (*id, n)).collect();
+                    npcs.sort_by_key(|(_, n)| n.symbol.clone());
+                    let list_items: Vec<ListItem> =
+                        npcs.iter().map(|(_, npc)| ListItem::new(npc.symbol.as_str())).collect();
                     let list = List::new(list_items)
                         .block(Block::default().title("NPCs").borders(Borders::ALL))
                         .highlight_style(Style::default().fg(Color::Yellow));
@@ -186,7 +225,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     state.select(Some(selected_npc));
                     f.render_stateful_widget(list, chunks[0], &mut state);
 
-                    let npc = npcs[selected_npc];
+                    let (_, npc) = npcs[selected_npc];
                     let mut detail = vec![
                         Line::from(vec![
                             Span::styled("Name: ", Style::default().fg(Color::Blue)),
@@ -284,6 +323,63 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         if event::poll(Duration::from_millis(200))? {
             if let Event::Key(key) = event::read()? {
+                if let Some(kind) = &editing {
+                    match key.code {
+                        KeyCode::Esc => {
+                            editing = None;
+                            input_buffer.clear();
+                        },
+                        KeyCode::Enter => {
+                            match kind {
+                                EditKind::Room => {
+                                    let mut ids: Vec<(Uuid, String)> =
+                                        world.rooms.iter().map(|(id, r)| (*id, r.symbol.clone())).collect();
+                                    ids.sort_by_key(|(_, sym)| sym.clone());
+                                    if let Some((room_id, _)) = ids.get(selected_room) {
+                                        if let Some(room) = world.rooms.get_mut(room_id) {
+                                            room.name = input_buffer.clone();
+                                        }
+                                    }
+                                },
+                                EditKind::Item => {
+                                    let mut ids: Vec<(Uuid, String)> =
+                                        world.items.iter().map(|(id, i)| (*id, i.symbol.clone())).collect();
+                                    ids.sort_by_key(|(_, sym)| sym.clone());
+                                    if let Some((item_id, _)) = ids.get(selected_item) {
+                                        if let Some(item) = world.items.get_mut(item_id) {
+                                            item.name = input_buffer.clone();
+                                        }
+                                    }
+                                },
+                                EditKind::Npc => {
+                                    let mut ids: Vec<(Uuid, String)> =
+                                        world.npcs.iter().map(|(id, n)| (*id, n.symbol.clone())).collect();
+                                    ids.sort_by_key(|(_, sym)| sym.clone());
+                                    if let Some((npc_id, _)) = ids.get(selected_npc) {
+                                        if let Some(npc) = world.npcs.get_mut(npc_id) {
+                                            npc.name = input_buffer.clone();
+                                        }
+                                    }
+                                },
+                                EditKind::Trigger => {
+                                    if let Some(trg) = world.triggers.get_mut(selected_trigger) {
+                                        trg.name = input_buffer.clone();
+                                    }
+                                },
+                            }
+                            editing = None;
+                            input_buffer.clear();
+                        },
+                        KeyCode::Char(c) => {
+                            input_buffer.push(c);
+                        },
+                        KeyCode::Backspace => {
+                            input_buffer.pop();
+                        },
+                        _ => {},
+                    }
+                    continue;
+                }
                 match key.code {
                     KeyCode::Char('q') => break,
                     KeyCode::Char('r') => {
@@ -297,6 +393,54 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     },
                     KeyCode::Char('t') => {
                         mode = ViewMode::Triggers;
+                    },
+
+                    KeyCode::Char('e') => {
+                        if editing.is_none() {
+                            editing = Some(match mode {
+                                ViewMode::Rooms => EditKind::Room,
+                                ViewMode::Items => EditKind::Item,
+                                ViewMode::Npcs => EditKind::Npc,
+                                ViewMode::Triggers => EditKind::Trigger,
+                            });
+                            input_buffer = match mode {
+                                ViewMode::Rooms => {
+                                    let mut items: Vec<(Uuid, String)> =
+                                        world.rooms.iter().map(|(id, r)| (*id, r.symbol.clone())).collect();
+                                    items.sort_by_key(|(_, sym)| sym.clone());
+                                    if let Some((id, _)) = items.get(selected_room) {
+                                        world.rooms.get(id).map(|r| r.name.clone()).unwrap_or_default()
+                                    } else {
+                                        String::new()
+                                    }
+                                },
+                                ViewMode::Items => {
+                                    let mut items: Vec<(Uuid, String)> =
+                                        world.items.iter().map(|(id, i)| (*id, i.symbol.clone())).collect();
+                                    items.sort_by_key(|(_, sym)| sym.clone());
+                                    if let Some((id, _)) = items.get(selected_item) {
+                                        world.items.get(id).map(|i| i.name.clone()).unwrap_or_default()
+                                    } else {
+                                        String::new()
+                                    }
+                                },
+                                ViewMode::Npcs => {
+                                    let mut items: Vec<(Uuid, String)> =
+                                        world.npcs.iter().map(|(id, n)| (*id, n.symbol.clone())).collect();
+                                    items.sort_by_key(|(_, sym)| sym.clone());
+                                    if let Some((id, _)) = items.get(selected_npc) {
+                                        world.npcs.get(id).map(|n| n.name.clone()).unwrap_or_default()
+                                    } else {
+                                        String::new()
+                                    }
+                                },
+                                ViewMode::Triggers => world
+                                    .triggers
+                                    .get(selected_trigger)
+                                    .map(|t| t.name.clone())
+                                    .unwrap_or_default(),
+                            };
+                        }
                     },
 
                     KeyCode::Down => match mode {


### PR DESCRIPTION
## Summary
- allow editing of names for rooms, items, NPCs and triggers
- show a text input box and update data on Enter
- add keybinding `e` to start editing mode

## Testing
- `cargo check` *(fails: `amble_engine` crate uses unstable features)*

------
https://chatgpt.com/codex/tasks/task_e_6883d5c99fe88324b9cfb4fc8a42492b