### PR TITLE
Add basic unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,7 @@ dependencies = [
  "rand",
  "ron",
  "serde",
+ "serde_json",
  "toml",
  "uuid 1.17.0",
  "variantly",
@@ -707,6 +708,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/amble_engine/Cargo.toml
+++ b/amble_engine/Cargo.toml
@@ -15,3 +15,6 @@ serde = { version = "1.0.219", features = ["derive"] }
 toml = "0.8.22"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 variantly = "0.4.0"
+
+[dev-dependencies]
+serde_json = "1.0"


### PR DESCRIPTION
## Summary
- add integration tests covering modules in amble_engine
- add serde_json as dev dependency for tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68869ee101348324866f3c47a71a61ea