### PR TITLE
Improve engine documentation

### DIFF
--- a/amble_engine/src/item.rs
+++ b/amble_engine/src/item.rs
@@ -1,3 +1,9 @@
+//! Item types and related helpers.
+//!
+//! Items represent objects the player can interact with. Some may act as
+//! containers for other items. Functions here handle display logic and
+//! movement between locations.
+
 use crate::{Location, WorldObject, style::GameStyle, world::AmbleWorld};
 
 use colored::Colorize;

--- a/amble_engine/src/lib.rs
+++ b/amble_engine/src/lib.rs
@@ -1,6 +1,12 @@
 #![warn(clippy::pedantic)]
 #![allow(clippy::must_use_candidate)]
 
+//! Amble game engine library.
+//!
+//! This crate contains the core data structures and logic that power the
+//! command line adventure game. It exposes a small API used by the binary
+//! in `main.rs` and by tooling.
+
 pub const AMBLE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // Core modules

--- a/amble_engine/src/loader.rs
+++ b/amble_engine/src/loader.rs
@@ -1,3 +1,8 @@
+//! Loader utilities for building an `AmbleWorld` from TOML files.
+//!
+//! Each submodule handles parsing and conversion of one data type such as rooms
+//! or items. The main [`load_world`] function ties them all together.
+
 pub mod goals;
 pub mod items;
 pub mod npcs;

--- a/amble_engine/src/loader/items.rs
+++ b/amble_engine/src/loader/items.rs
@@ -1,3 +1,8 @@
+//! Loading logic for [`Item`] definitions.
+//!
+//! Items are first parsed into [`RawItem`] structures and later converted into
+//! fully linked [`Item`] instances during world initialization.
+
 use std::{
     collections::{HashMap, HashSet},
     fs,

--- a/amble_engine/src/loader/player.rs
+++ b/amble_engine/src/loader/player.rs
@@ -1,3 +1,8 @@
+//! Player loading helpers.
+//!
+//! The player character is described in `player.toml`. This module reads the
+//! file and converts the raw representation into a [`Player`] instance.
+
 use std::{
     collections::{HashMap, HashSet},
     fs,

--- a/amble_engine/src/loader/rooms.rs
+++ b/amble_engine/src/loader/rooms.rs
@@ -1,3 +1,8 @@
+//! Room loading logic.
+//!
+//! Rooms are pre-registered in the symbol table and later populated with exits
+//! and overlays once all referenced objects are known.
+
 use std::{
     collections::{HashMap, HashSet},
     fs,

--- a/amble_engine/src/loader/triggers.rs
+++ b/amble_engine/src/loader/triggers.rs
@@ -1,3 +1,9 @@
+//! Helpers for loading [`Trigger`] definitions from TOML.
+//!
+//! Triggers combine game conditions with actions. This module converts the raw
+//! text representation into fully linked structures that the engine can
+//! evaluate at runtime.
+
 use std::{collections::HashSet, fs, path::Path};
 
 use anyhow::{Context, Result, bail};

--- a/amble_engine/src/player.rs
+++ b/amble_engine/src/player.rs
@@ -6,6 +6,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use uuid::Uuid;
 
+/// The player-controlled character.
+///
+/// This struct tracks the player's state, such as inventory, score and flags.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Player {
     pub id: Uuid,

--- a/amble_engine/src/repl.rs
+++ b/amble_engine/src/repl.rs
@@ -1,3 +1,8 @@
+//! REPL and command handling utilities.
+//!
+//! The game runs in a read-eval-print loop. This module and its submodules
+//! implement the various command handlers that manipulate the [`AmbleWorld`].
+
 pub mod inventory;
 pub mod item;
 pub mod look;

--- a/amble_engine/src/room.rs
+++ b/amble_engine/src/room.rs
@@ -5,6 +5,9 @@ use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
+/// An exit from one room to another.
+///
+/// Additional flags and items may be required to traverse it.
 pub struct Exit {
     pub to: Uuid,
     pub hidden: bool,
@@ -14,6 +17,7 @@ pub struct Exit {
     pub barred_message: Option<String>,
 }
 impl Exit {
+    /// Create a basic exit leading to the room with the given UUID.
     pub fn new(to: Uuid) -> Self {
         Self {
             to,

--- a/amble_engine/src/style.rs
+++ b/amble_engine/src/style.rs
@@ -1,5 +1,12 @@
+//! Styling helpers for terminal output.
+//!
+//! The [`GameStyle`] trait provides a set of convenience methods for applying
+//! ANSI styling via the `colored` crate. Implementations for `&str` and
+//! `String` are provided so string literals can be styled directly.
+
 use colored::{ColoredString, Colorize};
 
+/// Convenience trait for applying color and style to text output.
 pub trait GameStyle {
     fn item_style(&self) -> ColoredString;
     fn npc_style(&self) -> ColoredString;

--- a/amble_engine/src/world.rs
+++ b/amble_engine/src/world.rs
@@ -1,3 +1,8 @@
+//! Data structures representing the game world.
+//!
+//! This module defines [`AmbleWorld`] and related types used at runtime to
+//! track the current state of the adventure.
+
 use crate::AMBLE_VERSION;
 use crate::item::ContainerState;
 use crate::npc::Npc;
@@ -36,7 +41,11 @@ pub trait WorldObject {
     fn location(&self) -> &Location;
 }
 
-/// The Amble world.
+/// Complete state of the running game.
+///
+/// `AmbleWorld` contains every room, item, NPC and trigger currently active, as
+/// well as the player character. It is created during loading and then mutated
+/// throughout gameplay.
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct AmbleWorld {
     pub rooms: HashMap<Uuid, Room>,


### PR DESCRIPTION
## Summary
- add crate-level overview
- document modules lacking summaries
- expand data structure docs

## Testing
- `cargo check -p amble_engine` *(fails: `let` expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_e_6886af9a3b08832495df38d41d998df5