### PR TITLE
Route output through View

### DIFF
--- a/amble_engine/src/dev_command.rs
+++ b/amble_engine/src/dev_command.rs
@@ -4,10 +4,10 @@
 
 use log::warn;
 
-use crate::{DEV_MODE, command::Command, style::GameStyle};
+use crate::{DEV_MODE, command::Command, style::GameStyle, view::{View, ViewItem}};
 
 /// Parse developer-only commands if '`DEV_MODE`' is true.
-pub fn parse_dev_command(input: &str) -> Option<Command> {
+pub fn parse_dev_command(input: &str, view: &mut View) -> Option<Command> {
     if input.starts_with(':') {
         let words: Vec<&str> = input.trim_start_matches(':').split_whitespace().collect();
         let maybe_command = match words.as_slice() {
@@ -24,7 +24,9 @@ pub fn parse_dev_command(input: &str) -> Option<Command> {
             _ => None,
         };
         if maybe_command.is_some() && !DEV_MODE {
-            println!("{}", "Developer commands are disabled in this build.".error_style());
+            view.push(ViewItem::Error(
+                "Developer commands are disabled in this build.".error_style().to_string(),
+            ));
             warn!(
                 "player attempted to use developer command '{:?}' with DEV_MODE = false",
                 maybe_command.unwrap()

--- a/amble_engine/src/item.rs
+++ b/amble_engine/src/item.rs
@@ -190,7 +190,9 @@ impl Item {
                 } else {
                     "open".bold().green()
                 };
-                println!("You'll have to {action} it first.");
+                view.push(ViewItem::ActionFailure(format!(
+                    "You'll have to {action} it first."
+                )));
             }
         }
     }

--- a/amble_engine/src/repl/inventory.rs
+++ b/amble_engine/src/repl/inventory.rs
@@ -7,10 +7,10 @@ use std::collections::HashSet;
 use crate::{
     AmbleWorld, ItemHolder, Location, View, ViewItem, WorldObject,
     item::ItemInteractionType,
-    repl::{WorldEntity, entity_not_found, find_world_object},
+    repl::{entity_not_found, find_world_object, WorldEntity},
     spinners::SpinnerType,
     style::GameStyle,
-    trigger::{TriggerCondition, check_triggers},
+    trigger::{check_triggers, TriggerCondition},
     world::nearby_reachable_items,
 };
 
@@ -44,7 +44,7 @@ pub fn drop_handler(world: &mut AmbleWorld, view: &mut View, thing: &str) -> Res
                         "You dropped the {}.",
                         dropped.name().item_style()
                     )));
-                    check_triggers(world, &[TriggerCondition::Drop(item_id)])?;
+                    check_triggers(world, view, &[TriggerCondition::Drop(item_id)])?;
                 }
             } else {
                 // item not portable
@@ -64,7 +64,7 @@ pub fn drop_handler(world: &mut AmbleWorld, view: &mut View, thing: &str) -> Res
             Ok(())
         }
     } else {
-        entity_not_found(world, thing);
+        entity_not_found(world, view, thing);
         Ok(())
     }
 }
@@ -142,7 +142,7 @@ pub fn take_handler(world: &mut AmbleWorld, view: &mut View, thing: &str) -> Res
                         warn!("'take' matched an item at {orig_loc:?}: shouldn't be in scope");
                     },
                 }
-                check_triggers(world, &[TriggerCondition::Take(loot_id)])?;
+                check_triggers(world, view, &[TriggerCondition::Take(loot_id)])?;
             } else {
                 let reason = if item.restricted { "restricted" } else { "not portable" };
                 view.push(ViewItem::ActionFailure(format!(
@@ -159,7 +159,7 @@ pub fn take_handler(world: &mut AmbleWorld, view: &mut View, thing: &str) -> Res
             }
         }
     } else {
-        entity_not_found(world, thing);
+        entity_not_found(world, view, thing);
     }
     Ok(())
 }
@@ -205,7 +205,7 @@ pub fn take_from_handler(
                 return Ok(());
             }
         } else {
-            entity_not_found(world, vessel_pattern);
+            entity_not_found(world, view, vessel_pattern);
             return Ok(());
         };
 
@@ -268,6 +268,7 @@ pub(crate) fn validate_and_transfer_from_npc(
     );
     check_triggers(
         world,
+        view,
         &[
             TriggerCondition::Take(loot_id),
             TriggerCondition::TakeFromNpc {
@@ -325,7 +326,7 @@ pub(crate) fn validate_and_transfer_from_item(
         loot_id,
         &loot_name,
     );
-    check_triggers(world, &[TriggerCondition::Take(loot_id)])?;
+    check_triggers(world, view, &[TriggerCondition::Take(loot_id)])?;
     Ok(())
 }
 
@@ -394,7 +395,7 @@ pub fn put_in_handler(world: &mut AmbleWorld, view: &mut View, item: &str, conta
                 return Ok(());
             }
         } else {
-            entity_not_found(world, item);
+            entity_not_found(world, view, item);
             return Ok(());
         };
 
@@ -418,7 +419,7 @@ pub fn put_in_handler(world: &mut AmbleWorld, view: &mut View, item: &str, conta
                 return Ok(());
             }
         } else {
-            entity_not_found(world, container);
+            entity_not_found(world, view, container);
             return Ok(());
         };
 
@@ -447,6 +448,7 @@ pub fn put_in_handler(world: &mut AmbleWorld, view: &mut View, item: &str, conta
     );
     check_triggers(
         world,
+        view,
         &[
             TriggerCondition::Insert {
                 item: item_id,

--- a/amble_engine/src/repl/item.rs
+++ b/amble_engine/src/repl/item.rs
@@ -78,6 +78,7 @@ pub fn use_item_on_handler(
     let sent_tool_id = tool.id();
     let fired = check_triggers(
         world,
+        view,
         &[TriggerCondition::UseItemOnItem {
             interaction,
             target_id: target.id(),
@@ -113,6 +114,7 @@ pub fn turn_on_handler(world: &mut AmbleWorld, view: &mut View, item_pattern: &s
                 let sent_id = item.id();
                 let fired_triggers = check_triggers(
                     world,
+                    view,
                     &[TriggerCondition::UseItem {
                         item_id: sent_id,
                         ability: ItemAbility::TurnOn,
@@ -149,7 +151,7 @@ pub fn turn_on_handler(world: &mut AmbleWorld, view: &mut View, item_pattern: &s
             )));
         }
     } else {
-        entity_not_found(world, item_pattern);
+        entity_not_found(world, view, item_pattern);
     }
     Ok(())
 }
@@ -172,7 +174,7 @@ pub fn open_handler(world: &mut AmbleWorld, view: &mut View, pattern: &str) -> R
                 return Ok(());
             }
         } else {
-            entity_not_found(world, pattern);
+            entity_not_found(world, view, pattern);
             return Ok(());
         };
 
@@ -203,7 +205,7 @@ pub fn open_handler(world: &mut AmbleWorld, view: &mut View, pattern: &str) -> R
                     target_item.name().item_style()
                 )));
                 info!("{} opened the {} ({})", world.player.name(), name, container_id,);
-                check_triggers(world, &[TriggerCondition::Open(container_id)])?;
+                check_triggers(world, view, &[TriggerCondition::Open(container_id)])?;
             },
         }
     }
@@ -226,7 +228,7 @@ pub fn close_handler(world: &mut AmbleWorld, view: &mut View, pattern: &str) -> 
             return Ok(());
         }
     } else {
-        entity_not_found(world, pattern);
+        entity_not_found(world, view, pattern);
         return Ok(());
     };
 
@@ -272,7 +274,7 @@ pub fn lock_handler(world: &mut AmbleWorld, view: &mut View, pattern: &str) -> R
             return Ok(());
         }
     } else {
-        entity_not_found(world, pattern);
+        entity_not_found(world, view, pattern);
         return Ok(());
     };
 
@@ -319,7 +321,7 @@ pub fn unlock_handler(world: &mut AmbleWorld, view: &mut View, pattern: &str) ->
                 return Ok(());
             }
         } else {
-            entity_not_found(world, pattern);
+            entity_not_found(world, view, pattern);
             return Ok(());
         };
 
@@ -361,7 +363,7 @@ pub fn unlock_handler(world: &mut AmbleWorld, view: &mut View, pattern: &str) ->
                         container_name,
                         container_id
                     );
-                    check_triggers(world, &[TriggerCondition::Unlock(container_id)])?;
+                    check_triggers(world, view, &[TriggerCondition::Unlock(container_id)])?;
                 } else {
                     view.push(ViewItem::ActionFailure(format!(
                         "You don't have anything that can unlock the {}.",

--- a/amble_engine/src/repl/look.rs
+++ b/amble_engine/src/repl/look.rs
@@ -9,7 +9,7 @@ use crate::{
     item::ItemAbility,
     repl::{entity_not_found, find_world_object},
     style::GameStyle,
-    trigger::{TriggerAction, TriggerCondition, check_triggers},
+    trigger::{check_triggers, TriggerAction, TriggerCondition},
     view::{ContentLine, ViewMode},
     world::nearby_reachable_items,
 };
@@ -23,7 +23,7 @@ pub fn look_handler(world: &mut AmbleWorld, view: &mut View) -> Result<()> {
     let room = world.player_room_ref()?;
     room.show(world, view, Some(ViewMode::Verbose))?;
     info!("{} looked around {} ({})", world.player.name, room.name, room.id);
-    let _fired = check_triggers(world, &[]);
+    let _fired = check_triggers(world, view, &[]);
     Ok(())
 }
 
@@ -45,9 +45,9 @@ pub fn look_at_handler(world: &mut AmbleWorld, view: &mut View, thing: &str) -> 
             info!("{} looked at {} ({})", world.player.name(), npc.name(), npc.id());
             npc.show(world, view);
         }
-        let _fired = check_triggers(world, &[]);
+        let _fired = check_triggers(world, view, &[]);
     } else {
-        entity_not_found(world, thing);
+        entity_not_found(world, view, thing);
     }
     Ok(())
 }
@@ -101,13 +101,14 @@ pub fn read_handler(world: &mut AmbleWorld, view: &mut View, pattern: &str) -> R
             None
         }
     } else {
-        entity_not_found(world, pattern);
+        entity_not_found(world, view, pattern);
         return Ok(());
     };
     // check triggers for any DenyRead action that may have fired, and show the text if not
     if let Some(item_id) = found_item_id {
         let fired = check_triggers(
             world,
+            view,
             &[TriggerCondition::UseItem {
                 item_id,
                 ability: ItemAbility::Read,

--- a/amble_engine/src/repl/movement.rs
+++ b/amble_engine/src/repl/movement.rs
@@ -8,7 +8,7 @@ use crate::{
     AmbleWorld, Location, View, ViewItem, WorldObject,
     spinners::SpinnerType,
     style::GameStyle,
-    trigger::{TriggerCondition, check_triggers},
+    trigger::{check_triggers, TriggerCondition},
     view::ViewMode,
 };
 
@@ -83,6 +83,7 @@ pub fn move_to_handler(world: &mut AmbleWorld, view: &mut View, input_dir: &str)
             }
             check_triggers(
                 world,
+                view,
                 &[
                     TriggerCondition::Leave(leaving_id),
                     TriggerCondition::Enter(destination_id),

--- a/amble_engine/src/room.rs
+++ b/amble_engine/src/room.rs
@@ -157,7 +157,6 @@ impl Room {
         }
         self.show_exits(world, view)?;
         self.show_npcs(world, view);
-        println!();
         Ok(())
     }
 

--- a/amble_engine/tests/basic.rs
+++ b/amble_engine/tests/basic.rs
@@ -5,7 +5,9 @@ use amble_engine as ae;
 #[test]
 fn test_command_parse() {
     use ae::command::*;
-    assert!(matches!(parse_command("look"), Command::Look));
+    use ae::View;
+    let mut view = View::new();
+    assert!(matches!(parse_command("look", &mut view), Command::Look));
     assert_eq!(parse_interaction_type("burn"), Some(item::ItemInteractionType::Burn));
 }
 


### PR DESCRIPTION
## Summary
- Push command parsing, dev warnings, and game actions into `View` rather than printing directly
- Pass `&mut View` through REPL helpers and trigger handlers so messages aggregate correctly
- Extend tests and call sites to new signatures

## Testing
- `cargo test` *(fails: `let` expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_e_68994c8a65348324afe5d0341bbac96d