### PR TITLE
Added location history / go back command.

### DIFF
--- a/amble_engine/src/command.rs
+++ b/amble_engine/src/command.rs
@@ -21,6 +21,7 @@ pub enum Command {
         npc: String,
     },
     Goals,
+    GoBack,
     Help,
     Inventory,
     Load(String),
@@ -78,6 +79,7 @@ pub fn parse_command(input: &str, view: &mut View) -> Command {
     let words: Vec<&str> = lc_input.split_whitespace().collect();
     match words.as_slice() {
         ["goals"] | ["what", "now" | "next"] => Command::Goals,
+        ["back"] | ["go", "back"] | ["return"] => Command::GoBack,
         ["look"] => Command::Look,
         ["give", item, "to", npc] => Command::GiveToNpc {
             item: (*item).to_string(),
@@ -342,6 +344,14 @@ mod tests {
     #[test]
     fn parse_read_command() {
         assert_eq!(pc("read item"), Command::Read("item".into()));
+    }
+
+    #[test]
+    fn parse_go_back_command() {
+        let test_inputs = &["back", "go back", "return"];
+        for input in test_inputs {
+            assert_eq!(pc(input), Command::GoBack);
+        }
     }
 
     #[test]

--- a/amble_engine/src/loader/player.rs
+++ b/amble_engine/src/loader/player.rs
@@ -55,6 +55,7 @@ impl RawPlayer {
             name: self.name.to_string(),
             description: self.description.to_string(),
             location,
+            location_history: Vec::new(),
             inventory: HashSet::<Uuid>::default(),
             flags: HashSet::<Flag>::default(),
             score: self.score,

--- a/amble_engine/src/repl.rs
+++ b/amble_engine/src/repl.rs
@@ -81,6 +81,7 @@ pub fn run_repl(world: &mut AmbleWorld) -> Result<()> {
             },
             Command::Look => look_handler(world, &mut view)?,
             Command::LookAt(thing) => look_at_handler(world, &mut view, &thing)?,
+            Command::GoBack => go_back_handler(world, &mut view)?,
             Command::MoveTo(direction) => move_to_handler(world, &mut view, &direction)?,
             Command::Take(thing) => take_handler(world, &mut view, &thing)?,
             Command::TakeFrom { item, container } => take_from_handler(world, &mut view, &item, &container)?,


### PR DESCRIPTION
New location history Vec<Uuid> added to Player along with functions to track last 5 locations as a stack.
GoBack command ("go back" or just "back") goes to the previous location, up to 5 times. 
When the stack is empty reports to player. 

Consider: may want to make the history longer. Since it's a Vec of just Uuids, the memory impact would be negligible even with 100 moves tracked. 