### PR TITLE
Add feedback when portal gun is powered

### DIFF
--- a/amble_engine/data/rooms.toml
+++ b/amble_engine/data/rooms.toml
@@ -514,6 +514,10 @@ visited = false
 base_description = "A bare white room with a white tile floor. A ladder leads back up through the trap door in the ceiling. Three of the four walls are used as whiteboards, littered with obscure diagrams and equations. In the center, a black and white Portal gun is affixed to a pedestal and aimed squarely at the fourth wall."
 
 [[rooms.overlays]]
+conditions = [{ type = "flagSet", flag = "portal-gun-powered" }]
+text = "The portal gun's power indicator glows a steady green."
+
+[[rooms.overlays]]
 conditions = [{ type = "flagUnset", flag = "portal-opened" }]
 text = """A bullseye adorns the fourth, otherwise blank wall. A photo of a watch-sized computer attached to a potato battery is taped in the center, for some reason."""
 

--- a/amble_engine/data/triggers.toml
+++ b/amble_engine/data/triggers.toml
@@ -65,6 +65,7 @@ actions = [
     { type = "addFlag", flag = { type = "simple", name = "portal-gun-powered" } },
     { type = "awardPoints", amount = 3 },
     { type = "restrictItem", item_id = "charged_battery" },
+    { type = "setItemDescription", item_sym = "portal_gun", text = """A black and white Portal gun sits on its pedestal, aimed at a target on the wall. A fused battery juts from the compartment and the power indicator glows steadily green.""" },
     { type = "showMessage", text = """Arcing wildly as you insert it, the fully charged 20 KV battery fuses itself to the contacts inside the portal gun -- when then emits a quick high-pitched whine. The POWER indicator lights a steady green.""" },
 ]
 


### PR DESCRIPTION
## Summary
- Describe portal gun with fused battery and green power indicator after inserting charged battery
- Show room overlay in Portal Room when gun is powered

## Testing
- `cargo test`
- Manual: `:spawn charged_battery`, `:teleport portal-room`, `open gun`, `put battery in gun`, `look at gun`, `look`


------
https://chatgpt.com/codex/tasks/task_e_68b1290e7ee0832498636c585fc9e217