### PR TITLE
Mention EMH when entering Med Bay

### DIFF
--- a/amble_engine/data/rooms.toml
+++ b/amble_engine/data/rooms.toml
@@ -754,6 +754,33 @@ location = "Nowhere"
 visited = false
 base_description = "A clean white infirmary with two bio-beds extending from the back wall, surrounded by a bevy of monitors and robotic surgical tools. One of the machines goes \"Bing!\" every few minutes. A small cleaning robot floats around the room disinfecting things."
 
+[[rooms.overlays]]
+conditions = [
+    { type = "npcPresent", npc_id = "emh" },
+]
+text = "The Emergency Medical Hologram flickers beside the bio-beds, its emitter humming softly."
+
+[[rooms.overlays]]
+conditions = [
+    { type = "npcPresent", npc_id = "emh" },
+    { type = "npcInState", npc_id = "emh", state = "normal" },
+]
+text = "The EMH stands with professional detachment, awaiting your symptoms."
+
+[[rooms.overlays]]
+conditions = [
+    { type = "npcPresent", npc_id = "emh" },
+    { type = "npcInState", npc_id = "emh", state = "happy" },
+]
+text = "The EMH smiles and hums a bright tune while adjusting the diagnostic displays."
+
+[[rooms.overlays]]
+conditions = [
+    { type = "npcPresent", npc_id = "emh" },
+    { type = "npcInState", npc_id = "emh", state = { custom = "want-emitter" } },
+]
+text = "The EMH fidgets restlessly, casting longing glances toward the door as if craving a mobile emitter."
+
 [rooms.exits.west]
 to = "corridor-north"
 


### PR DESCRIPTION
## Summary
- Describe the EMH in Med Bay when he's present
- Add state-specific overlays for normal, happy, and want-emitter moods

## Testing
- `cargo fmt --all`
- `cargo test`
- `cargo run --bin amble_engine` then `:teleport med-bay`


------
https://chatgpt.com/codex/tasks/task_e_68b128ee6ff08324ad70250d2ad3e6ed