### PR TITLE
feat: add coffee brewed flag and lounge overlay

### DIFF
--- a/amble_engine/data/rooms.toml
+++ b/amble_engine/data/rooms.toml
@@ -468,6 +468,10 @@ conditions = [{ type = "flagUnset", flag = "found-portal-room" }]
 text = "An ornate rug lies in the center of the room. It really ties the room together."
 
 [[rooms.overlays]]
+conditions = [{ type = "flagSet", flag = "coffee-brewed" }]
+text = "The coffee machine emits a few satisfied clicks as the rich aroma of fresh coffee fills the lounge."
+
+[[rooms.overlays]]
 conditions = [
     { type = "npcPresent", npc_id = "gonk_droid" },
     { type = "npcInState", npc_id = "gonk_droid", state = "normal" },

--- a/amble_engine/data/triggers.toml
+++ b/amble_engine/data/triggers.toml
@@ -1182,11 +1182,20 @@ actions = [
     { type = "showMessage", text = "The coffee machine hums to life and begins its brewing cycle. A timer shows 3 minutes remaining..." },
     { type = "setItemDescription", item_sym = "coffee_machine", text = "A single serve drip coffee machine, which apparently takes quite a while to finish brewing a cup one drip at a time..." },
     { type = "scheduleIn", turns_ahead = 3, note = "Coffee brewing completes", actions = [
-        { type = "setItemDescription", item_sym = "coffee_machine", text = "A single serve, drip coffee maker. It appears the grounds have already been used." },
+        { type = "setItemDescription", item_sym = "coffee_machine", text = "A single serve, drip coffee maker. The brew cycle is complete and the grounds have already been used." },
         { type = "showMessage", text = "♪ BEEP BEEP BEEP! ♪ The coffee machine chimes cheerfully. The rich aroma of freshly brewed coffee fills the air." },
         { type = "spawnItemInRoom", item_id = "hot_coffee", room_id = "lounge" },
+        { type = "addFlag", flag = { type = "simple", name = "coffee-brewed" } },
         { type = "awardPoints", amount = 2 },
     ] },
+]
+
+[[triggers]]
+name = "Lounge: Coffee Taken"
+only_once = false
+conditions = [{ type = "take", item_id = "hot_coffee" }]
+actions = [
+    { type = "removeFlag", flag = "coffee-brewed" },
 ]
 
 [[triggers]]


### PR DESCRIPTION
## Summary
- mark lounge coffee machine's finished brew with a `coffee-brewed` flag
- show a fragrant coffee overlay in the lounge
- clear coffee flag when the cup is taken

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b13eaf78d8832497fdc5b8c6594895