### PR TITLE
Show empty pedestal when margarine is taken

### DIFF
--- a/amble_engine/data/rooms.toml
+++ b/amble_engine/data/rooms.toml
@@ -43,6 +43,10 @@ base_description = "The parish resembles a half-abandoned diner and half-absolve
 location = "Nowhere"
 visited = false
 
+[[rooms.overlays]]
+conditions = [{ type = "itemAbsent", item_id = "margarine" }]
+text = "The refrigerated pedestal hums solemnly in the corner, empty now that the tub of margarine is gone."
+
 [rooms.exits.east]
 to = "parish-landing"
 


### PR DESCRIPTION
## Summary
- Add overlay to Saint Alfonzo Parish that appears when the tub of margarine is gone

## Testing
- `cargo test`
- `cargo run -p amble_engine --bin check_overlay`

------
https://chatgpt.com/codex/tasks/task_e_68b13eb6d55c8324962c36d29547a6bc