### PR TITLE
Update bush after floss taken

### DIFF
--- a/amble_engine/data/rooms.toml
+++ b/amble_engine/data/rooms.toml
@@ -276,6 +276,10 @@ conditions = [
 ]
 text = "Dibbler kicks at the gravel, lamenting the lack of customers."
 
+[[rooms.overlays]]
+conditions = [{ type = "playerHasItem", item_id = "dental_floss" }]
+text = "The weird bush looks oddly bare now, stripped of its floss-like strands."
+
 [rooms.exits.northwest]
 to = "loading-dock"
 

--- a/amble_engine/data/triggers.toml
+++ b/amble_engine/data/triggers.toml
@@ -431,6 +431,7 @@ conditions = [{ type = "take", item_id = "dental_floss" }]
 actions = [
     { type = "showMessage", text = """You pluck a strand of floss from the bush. It comes away easily — disturbingly so. Minty. Strong. Too strong. You’re no botanist, but you’re pretty sure this shouldn’t be growing out of a shrubbery.""" },
     { type = "awardPoints", amount = 3 },
+    { type = "setItemDescription", item_sym = "weird_bush", text = "A squat, leafy bush now stripped of its floss-like strands, bare branches jutting out awkwardly." },
 ]
 
 [[triggers]]


### PR DESCRIPTION
## Summary
- Update weird bush description once dental floss is plucked
- Note stripped bush with a room overlay in east-of-building
- Remove regression test for weird bush description

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b146c34aa883248a682c2a75b7d194