### PR TITLE
Describe open Lost & Found box

### DIFF
--- a/amble_engine/data/rooms.toml
+++ b/amble_engine/data/rooms.toml
@@ -370,6 +370,10 @@ text = "The receptionist appears to be trying furtively to see what you have in 
 conditions = [{ type = "flagSet", flag = "got-visitor-pass" }]
 text = "The receptionist looks up from her desk and gives you an awkward wink and a grin."
 
+[[rooms.overlays]]
+conditions = [{ type = "flagSet", flag = "lost-and-found-opened" }]
+text = """The Lost & Found box sits with its lid hanging open, contents plainly visible."""
+
 [rooms.exits.east]
 to = "main-lobby"
 

--- a/amble_engine/data/triggers.toml
+++ b/amble_engine/data/triggers.toml
@@ -381,6 +381,7 @@ conditions = [{ type = "unlock", item_id = "lost_and_found_box" }]
 actions = [
     { type = "awardPoints", amount = 5 },
     { type = "addFlag", flag = { type = "simple", name = "lost-and-found-opened" } },
+    { type = "setItemDescription", item_sym = "lost_and_found_box", text = """The sturdy metal lock box's lid hangs open, its contents now visible.""" },
 ]
 
 # START FALLEN TREE TRIGGERS


### PR DESCRIPTION
## Summary
- Update Lost & Found unlock trigger to set a new open-box description
- Show overlay in Amble Adventures office when the Lost & Found box is open

## Testing
- `cargo test`
- `cargo run -p amble_engine --bin amble_engine` (teleport, spawn key, unlock and inspect box)

------
https://chatgpt.com/codex/tasks/task_e_68b149ac4c6083248a28871f0f112425