### PR TITLE
Add delayed lobby security reminder trigger

### DIFF
--- a/amble_engine/data/triggers.toml
+++ b/amble_engine/data/triggers.toml
@@ -1127,6 +1127,19 @@ actions = [
 ]
 
 [[triggers]]
+name = "Main-Lobby: Security Reminder"
+only_once = true
+conditions = [
+    { type = "enter", room_id = "main-lobby" },
+]
+actions = [
+    { type = "scheduleIn", turns_ahead = 3, note = "Lobby security reminder", actions = [
+        { type = "showMessage", text = """A chime echoes through the lobby. "Please do not loiter in the lobby," intones an overhead voice.""" },
+        { type = "awardPoints", amount = -1 },
+    ] },
+]
+
+[[triggers]]
 name = "Main-Lobby: Fish Out HAL Module"
 only_once = true
 conditions = [


### PR DESCRIPTION
## Summary
- schedule lobby security reminder after entering main-lobby
- deduct 1 point to show delayed consequences

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b364e984c483249b19a075827fadf9