### PR TITLE
Return symbol helpers as Option references

### DIFF
--- a/amble_engine/src/helpers.rs
+++ b/amble_engine/src/helpers.rs
@@ -8,21 +8,16 @@ use crate::{Item, Npc, Room};
 use uuid::Uuid;
 
 /// Returns the TOML symbol for a given room's uuid.
-pub fn room_symbol_from_id(rooms: &HashMap<Uuid, Room>, room_id: Uuid) -> String {
-    rooms
-        .get(&room_id)
-        .map_or_else(|| "<not_found>".to_string(), |room| room.symbol.clone())
+pub fn room_symbol_from_id(rooms: &HashMap<Uuid, Room>, room_id: Uuid) -> Option<&str> {
+    rooms.get(&room_id).map(|room| room.symbol.as_str())
 }
 
 /// Returns the TOML symbol for a given item's uuid.
-pub fn item_symbol_from_id(items: &HashMap<Uuid, Item>, item_id: Uuid) -> String {
-    items
-        .get(&item_id)
-        .map_or_else(|| "<not_found>".to_string(), |item| item.symbol.clone())
+pub fn item_symbol_from_id(items: &HashMap<Uuid, Item>, item_id: Uuid) -> Option<&str> {
+    items.get(&item_id).map(|item| item.symbol.as_str())
 }
 
 /// Returns the TOML symbol for a given character's uuid.
-pub fn npc_symbol_from_id(npcs: &HashMap<Uuid, Npc>, npc_id: Uuid) -> String {
-    npcs.get(&npc_id)
-        .map_or_else(|| "<not_found>".to_string(), |npc| npc.symbol.clone())
+pub fn npc_symbol_from_id(npcs: &HashMap<Uuid, Npc>, npc_id: Uuid) -> Option<&str> {
+    npcs.get(&npc_id).map(|npc| npc.symbol.as_str())
 }

--- a/amble_engine/src/npc.rs
+++ b/amble_engine/src/npc.rs
@@ -1,6 +1,6 @@
 //! NPC Module
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -15,8 +15,8 @@ use rand::{prelude::IndexedRandom, seq::IteratorRandom};
 use uuid::Uuid;
 
 use crate::{
-    helpers::room_symbol_from_id, spinners::CoreSpinnerType, view::ContentLine, world::AmbleWorld, ItemHolder,
-    Location, View, ViewItem, WorldObject,
+    ItemHolder, Location, View, ViewItem, WorldObject, helpers::room_symbol_from_id, spinners::CoreSpinnerType,
+    view::ContentLine, world::AmbleWorld,
 };
 
 /// A non-playable character.
@@ -181,18 +181,17 @@ pub fn move_npc(world: &mut AmbleWorld, view: &mut View, npc_id: Uuid, move_to: 
     if move_to.is_not_room() && move_to.is_not_nowhere() {
         bail!("tried to move NPC to invalid location {move_to:?}")
     }
-    let current_room_sym = match npc.location {
-        Location::Room(uuid) => room_symbol_from_id(&world.rooms, uuid),
-        _ => "<nowhere>".to_string(),
-    };
-    let dest_room_sym = match move_to {
-        Location::Room(uuid) => room_symbol_from_id(&world.rooms, uuid),
-        _ => "<nowhere>".to_string(),
-    };
-
     info!(
         "moving NPC '{}' from [{}] to [{}]",
-        npc.symbol, current_room_sym, dest_room_sym
+        npc.symbol,
+        match npc.location {
+            Location::Room(uuid) => room_symbol_from_id(&world.rooms, uuid).unwrap_or("<not_found>"),
+            _ => "<nowhere>",
+        },
+        match move_to {
+            Location::Room(uuid) => room_symbol_from_id(&world.rooms, uuid).unwrap_or("<not_found>"),
+            _ => "<nowhere>",
+        }
     );
 
     // get source and destination ids, or None where not a room

--- a/amble_engine/src/repl/dev.rs
+++ b/amble_engine/src/repl/dev.rs
@@ -316,6 +316,8 @@ mod tests {
     fn create_test_world() -> AmbleWorld {
         let mut world = AmbleWorld::default();
         world.player = Player::default();
+        // Disable colored output for consistent test assertions
+        colored::control::set_override(false);
         world
     }
 

--- a/amble_engine/src/repl/inventory.rs
+++ b/amble_engine/src/repl/inventory.rs
@@ -239,8 +239,8 @@ pub fn take_handler(world: &mut AmbleWorld, view: &mut View, thing: &str) -> Res
                         } else {
                             bail!(
                                 "container ({}) not found during Take({})",
-                                item_symbol_from_id(&world.items, container_id),
-                                item_symbol_from_id(&world.items, loot_id)
+                                item_symbol_from_id(&world.items, container_id).unwrap_or("<not_found>"),
+                                item_symbol_from_id(&world.items, loot_id).unwrap_or("<not_found>")
                             );
                         }
                     },
@@ -250,8 +250,8 @@ pub fn take_handler(world: &mut AmbleWorld, view: &mut View, thing: &str) -> Res
                         } else {
                             bail!(
                                 "room ({}) not found during Take({})",
-                                room_symbol_from_id(&world.rooms, room_id),
-                                item_symbol_from_id(&world.items, loot_id)
+                                room_symbol_from_id(&world.rooms, room_id).unwrap_or("<not_found>"),
+                                item_symbol_from_id(&world.items, loot_id).unwrap_or("<not_found>")
                             );
                         }
                     },
@@ -633,11 +633,11 @@ pub fn transfer_to_player(
         "{} took {} ({}) from {} ({})",
         world.player.name(),
         loot_name,
-        item_symbol_from_id(&world.items, loot_id),
+        item_symbol_from_id(&world.items, loot_id).unwrap_or("<not_found>"),
         vessel_name,
         match vessel_type {
-            VesselType::Item => item_symbol_from_id(&world.items, vessel_id),
-            VesselType::Npc => npc_symbol_from_id(&world.npcs, vessel_id),
+            VesselType::Item => item_symbol_from_id(&world.items, vessel_id).unwrap_or("<not_found>"),
+            VesselType::Npc => npc_symbol_from_id(&world.npcs, vessel_id).unwrap_or("<not_found>"),
         }
     );
 }
@@ -742,9 +742,9 @@ pub fn put_in_handler(world: &mut AmbleWorld, view: &mut View, item: &str, conta
         "{} put {} ({}) into {} ({})",
         world.player.name(),
         item_name,
-        item_symbol_from_id(&world.items, item_id),
+        item_symbol_from_id(&world.items, item_id).unwrap_or("<not_found>"),
         vessel_name,
-        item_symbol_from_id(&world.items, vessel_id)
+        item_symbol_from_id(&world.items, vessel_id).unwrap_or("<not_found>")
     );
 
     check_triggers(

--- a/amble_engine/src/repl/item.rs
+++ b/amble_engine/src/repl/item.rs
@@ -218,8 +218,8 @@ pub fn use_item_on_handler(
         ));
         info!(
             "No matching trigger for {interaction:?} {target_name} ({}) with {tool_name} ({})",
-            item_symbol_from_id(&world.items, target_id),
-            item_symbol_from_id(&world.items, tool_id)
+            item_symbol_from_id(&world.items, target_id).unwrap_or("<not_found>"),
+            item_symbol_from_id(&world.items, tool_id).unwrap_or("<not_found>")
         );
     }
     if tool_is_consumable {
@@ -409,7 +409,7 @@ pub fn open_handler(world: &mut AmbleWorld, view: &mut View, pattern: &str) -> R
                     "{} opened the {} ({})",
                     world.player.name(),
                     name,
-                    item_symbol_from_id(&world.items, container_id)
+                    item_symbol_from_id(&world.items, container_id).unwrap_or("<not_found>")
                 );
                 check_triggers(world, view, &[TriggerCondition::Open(container_id)])?;
             },
@@ -498,7 +498,7 @@ pub fn close_handler(world: &mut AmbleWorld, view: &mut View, pattern: &str) -> 
                     "{} closed the {} ({})",
                     world.player.name(),
                     name,
-                    item_symbol_from_id(&world.items, uuid)
+                    item_symbol_from_id(&world.items, uuid).unwrap_or("<not_found>")
                 );
             },
         }
@@ -580,7 +580,7 @@ pub fn lock_handler(world: &mut AmbleWorld, view: &mut View, pattern: &str) -> R
                     "{} locked the {} ({})",
                     world.player.name(),
                     name,
-                    item_symbol_from_id(&world.items, uuid)
+                    item_symbol_from_id(&world.items, uuid).unwrap_or("<not_found>")
                 );
             },
         }
@@ -690,7 +690,7 @@ pub fn unlock_handler(world: &mut AmbleWorld, view: &mut View, pattern: &str) ->
                         "{} unlocked the {} ({})",
                         world.player.name(),
                         container_name,
-                        item_symbol_from_id(&world.items, container_id)
+                        item_symbol_from_id(&world.items, container_id).unwrap_or("<not_found>")
                     );
                     check_triggers(world, view, &[TriggerCondition::Unlock(container_id)])?;
                 } else {

--- a/amble_engine/src/repl/npc.rs
+++ b/amble_engine/src/repl/npc.rs
@@ -295,9 +295,9 @@ pub fn give_to_npc_handler(world: &mut AmbleWorld, view: &mut View, item: &str, 
             "{} gave {} ({}) to {} ({})",
             world.player.name(),
             item_name,
-            item_symbol_from_id(&world.items, item_id),
+            item_symbol_from_id(&world.items, item_id).unwrap_or("<not_found>"),
             npc_name,
-            npc_symbol_from_id(&world.npcs, npc_id),
+            npc_symbol_from_id(&world.npcs, npc_id).unwrap_or("<not_found>"),
         );
     // trigger didn't fire, so NPC refuses the item by default; a specific refusal reason
     // can be defined for particular items by setting an `NpcRefuseItem` trigger action.
@@ -311,8 +311,8 @@ pub fn give_to_npc_handler(world: &mut AmbleWorld, view: &mut View, item: &str, 
         }
         info!(
             "{npc_name} ({}) refused a gift of {item_name} ({})",
-            npc_symbol_from_id(&world.npcs, npc_id),
-            item_symbol_from_id(&world.items, item_id)
+            npc_symbol_from_id(&world.npcs, npc_id).unwrap_or("<not_found>"),
+            item_symbol_from_id(&world.items, item_id).unwrap_or("<not_found>")
         );
     }
     Ok(())

--- a/amble_engine/src/trigger/action.rs
+++ b/amble_engine/src/trigger/action.rs
@@ -337,7 +337,7 @@ pub fn replace_item(world: &mut AmbleWorld, old_id: &Uuid, new_id: &Uuid) -> Res
     info!(
         "└─ action: ReplaceItem({}, {}) [Location = {location:?}",
         old_sym,
-        item_symbol_from_id(&world.items, *new_id)
+        item_symbol_from_id(&world.items, *new_id).unwrap_or("<not_found>")
     );
     Ok(())
 }
@@ -358,7 +358,7 @@ pub fn set_item_description(world: &mut AmbleWorld, item_id: &Uuid, text: &str) 
     // text is truncated below at max 50 chars for the log
     info!(
         "└─ action: SetItemDescription({}, \"{}\")",
-        item_symbol_from_id(&world.items, *item_id),
+        item_symbol_from_id(&world.items, *item_id).unwrap_or("<not_found>"),
         &text[..std::cmp::min(text.len(), 50)]
     );
     Ok(())
@@ -398,8 +398,8 @@ pub fn set_barred_message(world: &mut AmbleWorld, exit_from: &Uuid, exit_to: &Uu
     }
     info!(
         "└─ action: SetBarredMessage({} -> {}, '{msg}')",
-        room_symbol_from_id(&world.rooms, *exit_from),
-        room_symbol_from_id(&world.rooms, *exit_to)
+        room_symbol_from_id(&world.rooms, *exit_from).unwrap_or("<not_found>"),
+        room_symbol_from_id(&world.rooms, *exit_to).unwrap_or("<not_found>")
     );
     Ok(())
 }
@@ -757,7 +757,7 @@ pub fn lock_exit(world: &mut AmbleWorld, from_room: &Uuid, direction: &String) -
         exit.locked = true;
         info!(
             "└─ action: LockExit({direction}, from [{}]",
-            room_symbol_from_id(&world.rooms, *from_room)
+            room_symbol_from_id(&world.rooms, *from_room).unwrap_or("<not_found>")
         );
         Ok(())
     } else {
@@ -790,7 +790,7 @@ pub fn unlock_exit(world: &mut AmbleWorld, from_room: &Uuid, direction: &String)
         exit.locked = false;
         info!(
             "└─ action: UnlockExit({direction}, from [{}])",
-            room_symbol_from_id(&world.rooms, *from_room)
+            room_symbol_from_id(&world.rooms, *from_room).unwrap_or("<not_found>")
         );
         Ok(())
     } else {
@@ -818,7 +818,7 @@ pub fn unlock_item(world: &mut AmbleWorld, item_id: &Uuid) -> Result<()> {
             },
             Some(_) => warn!(
                 "action UnlockItem({}): item wasn't locked",
-                item_symbol_from_id(&world.items, *item_id)
+                item_symbol_from_id(&world.items, *item_id).unwrap_or("<not_found>")
             ),
             None => warn!("action UnlockItem({item_id}): item '{}' isn't a container", item.name()),
         }
@@ -874,7 +874,7 @@ pub fn spawn_item_in_specific_room(world: &mut AmbleWorld, item_id: &Uuid, room_
     info!(
         "└─ action: SpawnItemInRoom({}, {})",
         item.symbol(),
-        room_symbol_from_id(&world.rooms, *room_id)
+        room_symbol_from_id(&world.rooms, *room_id).unwrap_or("<not_found>")
     );
     item.set_location_room(*room_id);
     world
@@ -1032,7 +1032,9 @@ pub fn spawn_item_in_container(world: &mut AmbleWorld, item_id: &Uuid, container
     }
 
     // need to grab this here to avoid trouble with the borrow checker below
-    let container_sym = item_symbol_from_id(&world.items, *container_id);
+    let container_sym = item_symbol_from_id(&world.items, *container_id)
+        .unwrap_or("<not_found>")
+        .to_string();
 
     // then spawn again in the desired location
     let item = world
@@ -1146,8 +1148,8 @@ pub fn reveal_exit(world: &mut AmbleWorld, direction: &String, exit_from: &Uuid,
     exit.hidden = false;
     info!(
         "└─ action: RevealExit({direction}, from '{}', to '{}')",
-        room_symbol_from_id(&world.rooms, *exit_from),
-        room_symbol_from_id(&world.rooms, *exit_to)
+        room_symbol_from_id(&world.rooms, *exit_from).unwrap_or("<not_found>"),
+        room_symbol_from_id(&world.rooms, *exit_to).unwrap_or("<not_found>")
     );
     Ok(())
 }
@@ -1181,7 +1183,7 @@ pub fn push_player(world: &mut AmbleWorld, room_id: &Uuid) -> Result<()> {
         world.player.location = Location::Room(*room_id);
         info!(
             "└─ action: PushPlayerTo({})",
-            room_symbol_from_id(&world.rooms, *room_id)
+            room_symbol_from_id(&world.rooms, *room_id).unwrap_or("<not_found>")
         );
         Ok(())
     } else {


### PR DESCRIPTION
## Summary
- Return room/item/NPC symbol helpers as `Option<&str>`
- Update callers to handle missing symbols and only allocate strings when needed
- Disable ANSI colors in dev tests for stable comparisons

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b3646c69408324a4c30abfca3a6dd5