### PR TITLE
Handle player location errors gracefully

### DIFF
--- a/amble_engine/src/room.rs
+++ b/amble_engine/src/room.rs
@@ -325,7 +325,7 @@ mod tests {
             text: "This overlay should show".into(),
         };
 
-        assert!(overlay.applies(world.player.location.unwrap_room(), &world));
+        assert!(overlay.applies(world.player.location.room_id().unwrap(), &world));
     }
 
     #[test]
@@ -339,7 +339,7 @@ mod tests {
             text: "This overlay should not show".into(),
         };
 
-        assert!(!overlay.applies(world.player.location.unwrap_room(), &world));
+        assert!(!overlay.applies(world.player.location.room_id().unwrap(), &world));
     }
 
     #[test]
@@ -353,7 +353,7 @@ mod tests {
             text: "This overlay should show".into(),
         };
 
-        assert!(overlay.applies(world.player.location.unwrap_room(), &world));
+        assert!(overlay.applies(world.player.location.room_id().unwrap(), &world));
     }
 
     #[test]
@@ -371,13 +371,13 @@ mod tests {
             text: "Sequence is complete".into(),
         };
 
-        assert!(overlay.applies(world.player.location.unwrap_room(), &world));
+        assert!(overlay.applies(world.player.location.room_id().unwrap(), &world));
     }
 
     #[test]
     fn room_overlay_applies_with_item_present() {
         let world = create_test_world();
-        let room_id = world.player.location.unwrap_room();
+        let room_id = world.player.location.room_id().unwrap();
         let item_id = *world.items.keys().next().unwrap();
 
         let overlay = RoomOverlay {
@@ -391,7 +391,7 @@ mod tests {
     #[test]
     fn room_overlay_applies_with_item_absent() {
         let world = create_test_world();
-        let room_id = world.player.location.unwrap_room();
+        let room_id = world.player.location.room_id().unwrap();
         let nonexistent_item = Uuid::new_v4();
 
         let overlay = RoomOverlay {
@@ -416,7 +416,7 @@ mod tests {
             text: "You have the item".into(),
         };
 
-        assert!(overlay.applies(world.player.location.unwrap_room(), &world));
+        assert!(overlay.applies(world.player.location.room_id().unwrap(), &world));
     }
 
     #[test]
@@ -432,13 +432,13 @@ mod tests {
             text: "NPC is in normal mood".into(),
         };
 
-        assert!(overlay.applies(world.player.location.unwrap_room(), &world));
+        assert!(overlay.applies(world.player.location.room_id().unwrap(), &world));
     }
 
     #[test]
     fn room_overlay_applies_with_item_in_room() {
         let world = create_test_world();
-        let room_id = world.player.location.unwrap_room();
+        let room_id = world.player.location.room_id().unwrap();
         let item_id = *world.items.keys().next().unwrap();
 
         let overlay = RoomOverlay {
@@ -453,7 +453,7 @@ mod tests {
     fn room_show_displays_all_sections() {
         let mut world = create_test_world();
         let mut view = View::new();
-        let room_id = world.player.location.unwrap_room();
+        let room_id = world.player.location.room_id().unwrap();
 
         // Add items and NPCs to the room
         let item_id = *world.items.keys().next().unwrap();
@@ -493,7 +493,7 @@ mod tests {
     fn room_show_overlays_displays_applicable_overlays() {
         let mut world = create_test_world();
         let mut view = View::new();
-        let room_id = world.player.location.unwrap_room();
+        let room_id = world.player.location.room_id().unwrap();
 
         world
             .player
@@ -528,7 +528,7 @@ mod tests {
     fn room_show_npcs_displays_npc_list() {
         let mut world = create_test_world();
         let mut view = View::new();
-        let room_id = world.player.location.unwrap_room();
+        let room_id = world.player.location.room_id().unwrap();
         let npc_id = *world.npcs.keys().next().unwrap();
 
         world.rooms.get_mut(&room_id).unwrap().npcs.insert(npc_id);
@@ -548,7 +548,7 @@ mod tests {
     fn room_show_exits_displays_exit_list() {
         let mut world = create_test_world();
         let mut view = View::new();
-        let room_id = world.player.location.unwrap_room();
+        let room_id = world.player.location.room_id().unwrap();
 
         let dest_room_id = Uuid::new_v4();
         let dest_room = create_test_room(dest_room_id);
@@ -618,7 +618,7 @@ mod tests {
     fn room_show_handles_empty_sections() {
         let world = create_test_world();
         let mut view = View::new();
-        let room_id = world.player.location.unwrap_room();
+        let room_id = world.player.location.room_id().unwrap();
 
         let room = world.rooms.get(&room_id).unwrap();
         room.show(&world, &mut view, None).unwrap();
@@ -640,7 +640,7 @@ mod tests {
     fn exit_with_requirements_shows_correct_state() {
         let mut world = create_test_world();
         let mut view = View::new();
-        let room_id = world.player.location.unwrap_room();
+        let room_id = world.player.location.room_id().unwrap();
 
         let dest_room_id = Uuid::new_v4();
         let dest_room = create_test_room(dest_room_id);
@@ -671,7 +671,7 @@ mod tests {
     #[test]
     fn room_overlay_applies_with_player_missing_item() {
         let world = create_test_world();
-        let room_id = world.player.location.unwrap_room();
+        let room_id = world.player.location.room_id().unwrap();
         let missing_item = Uuid::new_v4();
 
         let overlay = RoomOverlay {
@@ -685,7 +685,7 @@ mod tests {
     #[test]
     fn room_overlay_applies_with_npc_present() {
         let mut world = create_test_world();
-        let room_id = world.player.location.unwrap_room();
+        let room_id = world.player.location.room_id().unwrap();
         let npc_id = *world.npcs.keys().next().unwrap();
         world.rooms.get_mut(&room_id).unwrap().npcs.insert(npc_id);
 
@@ -701,7 +701,7 @@ mod tests {
     fn room_show_exits_errors_if_destination_missing() {
         let mut world = create_test_world();
         let mut view = View::new();
-        let room_id = world.player.location.unwrap_room();
+        let room_id = world.player.location.room_id().unwrap();
         let missing_room = Uuid::new_v4();
         world
             .rooms

--- a/amble_engine/src/trigger/condition.rs
+++ b/amble_engine/src/trigger/condition.rs
@@ -128,7 +128,7 @@ impl TriggerCondition {
                 })
                 .is_some_and(Flag::is_complete),
             Self::HasVisited(room_id) => world.rooms.get(room_id).is_some_and(|r| r.visited),
-            Self::InRoom(room_id) => *room_id == world.player.location.unwrap_room(),
+            Self::InRoom(room_id) => world.player.location.room_id().map_or(false, |id| *room_id == id),
             Self::NpcHasItem { npc_id, item_id } => {
                 world.npcs.get(npc_id).is_some_and(|npc| npc.contains_item(*item_id))
             },

--- a/amble_engine/src/world.rs
+++ b/amble_engine/src/world.rs
@@ -32,6 +32,19 @@ pub enum Location {
     Room(Uuid),
 }
 
+impl Location {
+    /// Return the room id if this `Location` is [`Location::Room`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the location is not a room.
+    pub fn room_id(&self) -> Result<Uuid> {
+        self.room_ref()
+            .copied()
+            .ok_or_else(|| anyhow!("location is not a room"))
+    }
+}
+
 /// Methods common to any object in the world.
 pub trait WorldObject {
     fn id(&self) -> Uuid;
@@ -130,7 +143,7 @@ impl AmbleWorld {
     }
 }
 
-/// Collects and returns a set of items from a location according to a predicate function. 
+/// Collects and returns a set of items from a location according to a predicate function.
 /// Items contained in the room itself are always part of the set.
 /// Items within containers are only included if the container fits the predicate (open, open or transparent, etc.)
 fn collect_room_items(
@@ -275,16 +288,15 @@ mod tests {
     }
 
     #[test]
-    fn location_unwrap_room_works() {
+    fn location_room_id_works() {
         let room_id = Uuid::new_v4();
         let location = Location::Room(room_id);
-        assert_eq!(location.unwrap_room(), room_id);
+        assert_eq!(location.room_id().unwrap(), room_id);
     }
 
     #[test]
-    #[should_panic]
-    fn location_unwrap_room_panics_on_non_room() {
-        Location::Inventory.unwrap_room();
+    fn location_room_id_errors_on_non_room() {
+        assert!(Location::Inventory.room_id().is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add `Location::room_id` for fallible room lookups
- Use `room_id` in movement handlers and trigger conditions
- Notify the player when actions are attempted outside a room

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b363e152bc83248d9d4d9f8359724d