### PR TITLE
DEV commands expanded. Fixes #73.

### DIFF
--- a/amble_engine/src/command.rs
+++ b/amble_engine/src/command.rs
@@ -13,7 +13,6 @@ use crate::{
 /// Commands that can be executed by the player.
 #[derive(Debug, Clone, PartialEq, Variantly)]
 pub enum Command {
-    AdvanceSeq(String), // DEV_MODE only
     Close(String),
     Drop(String),
     GiveToNpc {
@@ -36,11 +35,8 @@ pub enum Command {
     },
     Quit,
     Read(String),
-    ResetSeq(String), // DEV_MODE only
     Save(String),
-    SetFlag(String), // DEV_MODE only
     SetViewMode(ViewMode),
-    SpawnItem(String), // DEV_MODE only
     StartSeq {
         // DEV_MODE only
         seq_name: String,
@@ -52,7 +48,6 @@ pub enum Command {
         container: String,
     },
     TalkTo(String),
-    Teleport(String), // DEV_MODE only
     Theme(String),
     TurnOn(String),
     Unknown,
@@ -62,6 +57,16 @@ pub enum Command {
         tool: String,
         target: String,
     },
+    // Commands below can only be used when crate::DEV_MODE is set when built.
+    HelpDev,
+    ListNpcs,
+    ListFlags,
+    ListSched,
+    AdvanceSeq(String),
+    ResetSeq(String),
+    SetFlag(String),
+    SpawnItem(String),
+    Teleport(String),
 }
 
 /// Parses an input string and returns a corresponding `Command` if recognized.

--- a/amble_engine/src/dev_command.rs
+++ b/amble_engine/src/dev_command.rs
@@ -27,6 +27,10 @@ pub fn parse_dev_command(input: &str, view: &mut View) -> Option<Command> {
     if input.starts_with(':') {
         let words: Vec<&str> = input.trim_start_matches(':').split_whitespace().collect();
         let maybe_command = match words.as_slice() {
+            ["help", "dev"] => Some(Command::HelpDev),
+            ["npcs"] => Some(Command::ListNpcs),
+            ["flags"] => Some(Command::ListFlags),
+            ["sched"] | ["schedule"] => Some(Command::ListSched),
             ["teleport" | "port", room_symbol] => Some(Command::Teleport((*room_symbol).into())),
             ["spawn" | "item", item_symbol] => Some(Command::SpawnItem((*item_symbol).into())),
             ["adv-seq", seq_name] => Some(Command::AdvanceSeq((*seq_name).into())),

--- a/amble_engine/src/repl.rs
+++ b/amble_engine/src/repl.rs
@@ -81,6 +81,7 @@ pub fn run_repl(world: &mut AmbleWorld) -> Result<()> {
             SetViewMode(mode) => set_viewmode_handler(&mut view, mode),
             Goals => goals_handler(world, &mut view),
             Help => help_handler(&mut view),
+            HelpDev => help_handler_dev(&mut view),
             Quit => {
                 if let ReplControl::Quit = quit_handler(world, &mut view)? {
                     view.flush();
@@ -109,8 +110,6 @@ pub fn run_repl(world: &mut AmbleWorld) -> Result<()> {
                 ));
             },
             TalkTo(npc_name) => talk_to_handler(world, &mut view, &npc_name)?,
-            Teleport(room_symbol) => dev_teleport_handler(world, &mut view, &room_symbol),
-            SpawnItem(item_symbol) => dev_spawn_item_handler(world, &mut view, &item_symbol),
             GiveToNpc { item, npc } => give_to_npc_handler(world, &mut view, &item, &npc)?,
             TurnOn(thing) => turn_on_handler(world, &mut view, &thing)?,
             Read(thing) => read_handler(world, &mut view, &thing)?,
@@ -120,6 +119,12 @@ pub fn run_repl(world: &mut AmbleWorld) -> Result<()> {
             UseItemOn { verb, tool, target } => {
                 use_item_on_handler(world, &mut view, verb, &tool, &target)?;
             },
+            // Commands below only available when crate::DEV_MODE is enabled.
+            SpawnItem(item_symbol) => dev_spawn_item_handler(world, &mut view, &item_symbol),
+            Teleport(room_symbol) => dev_teleport_handler(world, &mut view, &room_symbol),
+            ListNpcs => dev_list_npcs_handler(world, &mut view),
+            ListFlags => dev_list_flags_handler(world, &mut view),
+            ListSched => dev_list_sched_handler(world, &mut view),
             AdvanceSeq(seq_name) => dev_advance_seq_handler(world, &mut view, &seq_name),
             ResetSeq(seq_name) => dev_reset_seq_handler(world, &mut view, &seq_name),
             SetFlag(flag_name) => dev_set_flag_handler(world, &mut view, &flag_name),

--- a/amble_engine/src/view.rs
+++ b/amble_engine/src/view.rs
@@ -363,14 +363,38 @@ impl View {
             println!("{}", fill(basic_text, normal_block()).italic().cyan());
             println!();
 
-            // Print "Some Common Commands:" header
+            // Partition commands into normal vs DEV (':'-prefixed)
+            let (dev_cmds, normal_cmds): (Vec<_>, Vec<_>) = commands
+                .iter()
+                .cloned()
+                .partition(|c| c.command.starts_with(':'));
+
+            // Print normal commands section
             println!("{}", "Some Common Commands:".bold().yellow());
             println!();
-
-            // Print each command with formatting and proper text wrapping
-            for command in commands {
-                let formatted_line = format!("{} - {}", command.command.bold().green(), command.description.italic());
+            for command in &normal_cmds {
+                let formatted_line = format!(
+                    "{} - {}",
+                    command.command.bold().green(),
+                    command.description.italic()
+                );
                 println!("{}", fill(&formatted_line, normal_block()));
+            }
+
+            // Print developer commands section if present and DEV_MODE
+            if crate::DEV_MODE && !dev_cmds.is_empty() {
+                println!();
+                println!("{}", "Developer Commands (DEV_MODE):".bold().yellow());
+                println!();
+                for command in &dev_cmds {
+                    let desc = command
+                        .description
+                        .strip_prefix("DEV: ")
+                        .unwrap_or(&command.description)
+                        .to_string();
+                    let formatted_line = format!("{} - {}", command.command.bold().green(), desc.italic());
+                    println!("{}", fill(&formatted_line, normal_block()));
+                }
             }
         }
     }


### PR DESCRIPTION
#### New DEV_MODE commands added:
- :npcs -- lists NPCs, their locations and states
- :sched -- lists all pending items in the scheduler
- :flags -- shows all current flags set 

Generic 'help' now shows DEV commands but only if compiled with DEV_MODE set. 
:help or help dev filters to show only developer commands.
