### PR TITLE
Allow overlay conditions without parentheses

### DIFF
--- a/amble_script/docs/rooms_dsl_guide.md
+++ b/amble_script/docs/rooms_dsl_guide.md
@@ -63,6 +63,8 @@ Notes:
 
 ## Overlays
 
+Overlay condition lists can be written directly after `if` or wrapped in parentheses for clarity. The following examples omit parentheses, but `overlay if (flag set got-towel) { ... }` would also be valid.
+
 ```
 room front-entrance {
   name "Front Entrance"

--- a/amble_script/src/grammar.pest
+++ b/amble_script/src/grammar.pest
@@ -261,9 +261,10 @@ exit_opt  = {
 flag_req = { ("simple" ~ ident) | ("seq" ~ ident ~ ("limit" ~ number)?) }
 
 // Overlays
-overlay_stmt      = { "overlay" ~ "if" ~ overlay_cond_list ~ overlay_block }
+// Allow optional parentheses around the overlay condition list for cleaner syntax
+overlay_stmt      = { "overlay" ~ "if" ~ (overlay_cond_list | "(" ~ overlay_cond_list ~ ")") ~ overlay_block }
 overlay_block     = { "{" ~ "text" ~ string ~ "}" }
-overlay_cond_list = { "(" ~ overlay_cond ~ ("," ~ overlay_cond)* ~ ")" }
+overlay_cond_list = { overlay_cond ~ ("," ~ overlay_cond)* }
 overlay_cond      = {
     ("flag" ~ "set" ~ ident)
   | ("flag" ~ "unset" ~ ident)


### PR DESCRIPTION
## Summary
- support overlay condition lists without parentheses in the DSL
- document optional parentheses for overlay conditions

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68bf97ca29e48324882027e7038a9f50