### PR TITLE
Add paired overlay syntax for rooms

### DIFF
--- a/amble_script/docs/rooms_dsl_guide.md
+++ b/amble_script/docs/rooms_dsl_guide.md
@@ -88,6 +88,20 @@ room front-entrance {
 }
 ```
 
+For paired binary conditions like flags or presence checks, you can group the two outcomes into a single overlay block:
+
+```
+room locker-room {
+  name "Locker Room"
+  desc "..."
+
+  overlay if flag has-key {
+    set "The locker hangs open."
+    unset "The locker door is tightly shut."
+  }
+}
+```
+
 Emits overlay entries:
 
 ```

--- a/amble_script/src/grammar.pest
+++ b/amble_script/src/grammar.pest
@@ -243,7 +243,7 @@ cond_list = { cond ~ ("," ~ cond)* }
 
 room_def     = { "room" ~ ident ~ room_block }
 room_block   = { "{" ~ room_stmt* ~ "}" }
-room_stmt    = { room_name | room_desc | room_visited | exit_stmt | overlay_stmt }
+room_stmt    = { room_name | room_desc | room_visited | exit_stmt | overlay_stmt | overlay_flag_pair_stmt | overlay_item_pair_stmt | overlay_npc_pair_stmt }
 room_name    = { "name" ~ string }
 room_desc    = { ("desc" | "description") ~ string }
 room_visited = { "visited" ~ boolean }
@@ -278,3 +278,9 @@ overlay_cond      = {
   | ("npc" ~ "in" ~ "state" ~ ident ~ (ident | ("custom" ~ string)))
   | ("item" ~ "in" ~ "room" ~ ident ~ ident)
 }
+
+overlay_flag_pair_stmt   = { "overlay" ~ "if" ~ "flag" ~ ident ~ overlay_flag_pair_block }
+overlay_flag_pair_block  = { "{" ~ "set" ~ string ~ "unset" ~ string ~ "}" }
+overlay_item_pair_stmt   = { "overlay" ~ "if" ~ "item" ~ ident ~ overlay_presence_pair_block }
+overlay_npc_pair_stmt    = { "overlay" ~ "if" ~ "npc" ~ ident ~ overlay_presence_pair_block }
+overlay_presence_pair_block = { "{" ~ "present" ~ string ~ "absent" ~ string ~ "}" }

--- a/amble_script/src/parser.rs
+++ b/amble_script/src/parser.rs
@@ -441,7 +441,11 @@ fn parse_room_pair(room: pest::iterators::Pair<Rule>, _source: &str) -> Result<R
             Rule::exit_stmt => {
                 let mut it = inner_stmt.into_inner();
                 let dir = it.next().ok_or(AstError::Shape("exit direction"))?.as_str().to_string();
-                let to = it.next().ok_or(AstError::Shape("exit destination"))?.as_str().to_string();
+                let to = it
+                    .next()
+                    .ok_or(AstError::Shape("exit destination"))?
+                    .as_str()
+                    .to_string();
                 // Defaults
                 let mut hidden = false;
                 let mut locked = false;
@@ -453,8 +457,14 @@ fn parse_room_pair(room: pest::iterators::Pair<Rule>, _source: &str) -> Result<R
                         for opt in next.into_inner() {
                             // Simplest detection by textual head, then use children for values
                             let opt_text = opt.as_str().trim();
-                            if opt_text == "hidden" { hidden = true; continue; }
-                            if opt_text == "locked" { locked = true; continue; }
+                            if opt_text == "hidden" {
+                                hidden = true;
+                                continue;
+                            }
+                            if opt_text == "locked" {
+                                locked = true;
+                                continue;
+                            }
 
                             // pull children
                             let children: Vec<_> = opt.clone().into_inner().collect();
@@ -464,7 +474,9 @@ fn parse_room_pair(room: pest::iterators::Pair<Rule>, _source: &str) -> Result<R
                                 continue;
                             }
                             // required_items(...): list of idents only
-                            if children.iter().all(|p| p.as_rule() == Rule::ident) && opt_text.starts_with("required_items") {
+                            if children.iter().all(|p| p.as_rule() == Rule::ident)
+                                && opt_text.starts_with("required_items")
+                            {
                                 for idp in children {
                                     required_items.push(idp.as_str().to_string());
                                 }
@@ -480,7 +492,8 @@ fn parse_room_pair(room: pest::iterators::Pair<Rule>, _source: &str) -> Result<R
                                         Rule::flag_req => {
                                             // Extract ident child and keep only base name (ignore step/end since equality is by name)
                                             let mut itf = frp.into_inner();
-                                            let ident = itf.next().ok_or(AstError::Shape("flag ident"))?.as_str().to_string();
+                                            let ident =
+                                                itf.next().ok_or(AstError::Shape("flag ident"))?.as_str().to_string();
                                             let base = ident.split('#').next().unwrap_or(&ident).to_string();
                                             required_flags.push(base);
                                         },
@@ -492,7 +505,17 @@ fn parse_room_pair(room: pest::iterators::Pair<Rule>, _source: &str) -> Result<R
                         }
                     }
                 }
-                exits.push((dir, crate::ExitAst { to, hidden, locked, barred_message, required_flags, required_items }));
+                exits.push((
+                    dir,
+                    crate::ExitAst {
+                        to,
+                        hidden,
+                        locked,
+                        barred_message,
+                        required_flags,
+                        required_items,
+                    },
+                ));
             },
             Rule::overlay_stmt => {
                 // overlay if <cond_list> { text "..." }
@@ -501,7 +524,9 @@ fn parse_room_pair(room: pest::iterators::Pair<Rule>, _source: &str) -> Result<R
                 let conds_pair = it.next().ok_or(AstError::Shape("overlay cond list"))?;
                 let mut conds = Vec::new();
                 for cp in conds_pair.into_inner() {
-                    if cp.as_rule() != Rule::overlay_cond { continue; }
+                    if cp.as_rule() != Rule::overlay_cond {
+                        continue;
+                    }
                     let text = cp.as_str().trim();
                     let mut kids = cp.clone().into_inner();
                     if let Some(stripped) = text.strip_prefix("flag set ") {
@@ -558,16 +583,21 @@ fn parse_room_pair(room: pest::iterators::Pair<Rule>, _source: &str) -> Result<R
                         let npc = kids.next().ok_or(AstError::Shape("npc id"))?.as_str().to_string();
                         let nxt = kids.next().ok_or(AstError::Shape("state token"))?;
                         let oc = match nxt.as_rule() {
-                            Rule::ident => {
-                                crate::OverlayCondAst::NpcInState { npc, state: crate::NpcStateValue::Named(nxt.as_str().to_string()) }
+                            Rule::ident => crate::OverlayCondAst::NpcInState {
+                                npc,
+                                state: crate::NpcStateValue::Named(nxt.as_str().to_string()),
                             },
-                            Rule::string => {
-                                crate::OverlayCondAst::NpcInState { npc, state: crate::NpcStateValue::Custom(unquote(nxt.as_str())) }
+                            Rule::string => crate::OverlayCondAst::NpcInState {
+                                npc,
+                                state: crate::NpcStateValue::Custom(unquote(nxt.as_str())),
                             },
                             _ => {
                                 let mut sub = nxt.into_inner();
                                 let sval = sub.next().ok_or(AstError::Shape("custom string"))?;
-                                crate::OverlayCondAst::NpcInState { npc, state: crate::NpcStateValue::Custom(unquote(sval.as_str())) }
+                                crate::OverlayCondAst::NpcInState {
+                                    npc,
+                                    state: crate::NpcStateValue::Custom(unquote(sval.as_str())),
+                                }
                             },
                         };
                         conds.push(oc);
@@ -590,14 +620,76 @@ fn parse_room_pair(room: pest::iterators::Pair<Rule>, _source: &str) -> Result<R
                         break;
                     }
                 }
-                overlays.push(crate::OverlayAst { conditions: conds, text: txt });
+                overlays.push(crate::OverlayAst {
+                    conditions: conds,
+                    text: txt,
+                });
+            },
+            Rule::overlay_flag_pair_stmt => {
+                // overlay if flag <id> { set "..." unset "..." }
+                let mut it = inner_stmt.into_inner();
+                let flag = it.next().ok_or(AstError::Shape("flag name"))?.as_str().to_string();
+                let block = it.next().ok_or(AstError::Shape("flag pair block"))?;
+                let mut bi = block.into_inner();
+                let set_txt = unquote(bi.next().ok_or(AstError::Shape("set text"))?.as_str());
+                let unset_txt = unquote(bi.next().ok_or(AstError::Shape("unset text"))?.as_str());
+                overlays.push(crate::OverlayAst {
+                    conditions: vec![crate::OverlayCondAst::FlagSet(flag.clone())],
+                    text: set_txt,
+                });
+                overlays.push(crate::OverlayAst {
+                    conditions: vec![crate::OverlayCondAst::FlagUnset(flag)],
+                    text: unset_txt,
+                });
+            },
+            Rule::overlay_item_pair_stmt => {
+                // overlay if item <id> { present "..." absent "..." }
+                let mut it = inner_stmt.into_inner();
+                let item = it.next().ok_or(AstError::Shape("item id"))?.as_str().to_string();
+                let block = it.next().ok_or(AstError::Shape("item pair block"))?;
+                let mut bi = block.into_inner();
+                let present_txt = unquote(bi.next().ok_or(AstError::Shape("present text"))?.as_str());
+                let absent_txt = unquote(bi.next().ok_or(AstError::Shape("absent text"))?.as_str());
+                overlays.push(crate::OverlayAst {
+                    conditions: vec![crate::OverlayCondAst::ItemPresent(item.clone())],
+                    text: present_txt,
+                });
+                overlays.push(crate::OverlayAst {
+                    conditions: vec![crate::OverlayCondAst::ItemAbsent(item)],
+                    text: absent_txt,
+                });
+            },
+            Rule::overlay_npc_pair_stmt => {
+                // overlay if npc <id> { present "..." absent "..." }
+                let mut it = inner_stmt.into_inner();
+                let npc = it.next().ok_or(AstError::Shape("npc id"))?.as_str().to_string();
+                let block = it.next().ok_or(AstError::Shape("npc pair block"))?;
+                let mut bi = block.into_inner();
+                let present_txt = unquote(bi.next().ok_or(AstError::Shape("present text"))?.as_str());
+                let absent_txt = unquote(bi.next().ok_or(AstError::Shape("absent text"))?.as_str());
+                overlays.push(crate::OverlayAst {
+                    conditions: vec![crate::OverlayCondAst::NpcPresent(npc.clone())],
+                    text: present_txt,
+                });
+                overlays.push(crate::OverlayAst {
+                    conditions: vec![crate::OverlayCondAst::NpcAbsent(npc)],
+                    text: absent_txt,
+                });
             },
             _ => {},
         }
     }
     let name = name.ok_or(AstError::Shape("room missing name"))?;
     let desc = desc.ok_or(AstError::Shape("room missing desc"))?;
-    Ok(RoomAst { id, name, desc, visited: visited.unwrap_or(false), exits, overlays, src_line })
+    Ok(RoomAst {
+        id,
+        name,
+        desc,
+        visited: visited.unwrap_or(false),
+        exits,
+        overlays,
+        src_line,
+    })
 }
 
 /// Parse only rooms from a source (helper/testing).
@@ -799,17 +891,24 @@ fn extract_body(src: &str) -> Result<&str, AstError> {
             },
             '#' => {
                 // Treat '#' as a comment only if it begins the line (ignoring leading spaces)
-                if at_line_start { in_comment = true; }
+                if at_line_start {
+                    in_comment = true;
+                }
                 at_line_start = false;
             },
             '{' => {
-                if depth == 0 { start = Some(i + 1); }
+                if depth == 0 {
+                    start = Some(i + 1);
+                }
                 depth += 1;
                 at_line_start = false;
             },
             '}' => {
                 depth -= 1;
-                if depth == 0 { end = Some(i); break; }
+                if depth == 0 {
+                    end = Some(i);
+                    break;
+                }
                 at_line_start = false;
             },
             _ => {

--- a/amble_script/tests/fixtures/rooms_overlay_flag_pair.toml
+++ b/amble_script/tests/fixtures/rooms_overlay_flag_pair.toml
@@ -1,0 +1,15 @@
+# room test (source line 1)
+[[rooms]]
+id = "test"
+name = "Test"
+base_description = "Desc"
+location = "Nowhere"
+
+[[rooms.overlays]]
+conditions = [{ type = "flagSet", flag = "foo" }]
+text = "Foo Is Set"
+
+[[rooms.overlays]]
+conditions = [{ type = "flagUnset", flag = "foo" }]
+text = "Foo Is Not Set"
+

--- a/amble_script/tests/rooms_golden.rs
+++ b/amble_script/tests/rooms_golden.rs
@@ -13,3 +13,65 @@ fn minimal_room_multiline_desc_golden() {
     let expected = include_str!("fixtures/rooms_minimal_high_ridge.toml");
     assert_eq!(actual.trim(), expected.trim());
 }
+
+#[test]
+fn overlay_flag_pair_golden() {
+    let src = r#"room test {
+    name "Test"
+    desc "Desc"
+    overlay if flag foo {
+        set "Foo Is Set"
+        unset "Foo Is Not Set"
+    }
+}"#;
+    let rooms = parse_rooms(src).expect("parse rooms ok");
+    assert_eq!(rooms.len(), 1);
+    assert_eq!(rooms[0].overlays.len(), 2);
+    let actual = compile_rooms_to_toml(&rooms).expect("compile ok");
+    let expected = include_str!("fixtures/rooms_overlay_flag_pair.toml");
+    assert_eq!(actual.trim(), expected.trim());
+}
+
+#[test]
+fn overlay_item_pair_parses() {
+    let src = r#"room test {
+    name "Test"
+    desc "Desc"
+    overlay if item widget {
+        present "Widget here"
+        absent "Widget missing"
+    }
+}"#;
+    let rooms = parse_rooms(src).expect("parse rooms ok");
+    assert_eq!(rooms[0].overlays.len(), 2);
+    assert!(matches!(
+        rooms[0].overlays[0].conditions[0],
+        amble_script::OverlayCondAst::ItemPresent(_)
+    ));
+    assert!(matches!(
+        rooms[0].overlays[1].conditions[0],
+        amble_script::OverlayCondAst::ItemAbsent(_)
+    ));
+}
+
+#[test]
+fn overlay_npc_pair_parses() {
+    let src = r#"room test {
+    name "Test"
+    desc "Desc"
+    overlay if npc bob {
+        present "Bob waves"
+        absent "Bob is gone"
+    }
+}"#;
+    let rooms = parse_rooms(src).expect("parse rooms ok");
+    assert_eq!(rooms[0].overlays.len(), 2);
+    assert!(matches!(
+        rooms[0].overlays[0].conditions[0],
+        amble_script::OverlayCondAst::NpcPresent(_)
+    ));
+    assert!(matches!(
+        rooms[0].overlays[1].conditions[0],
+        amble_script::OverlayCondAst::NpcAbsent(_)
+    ));
+}


### PR DESCRIPTION
## Summary
- allow `overlay if flag|item|npc <id> { set/present ... unset/absent ... }` blocks for paired overlay conditions
- document paired overlay syntax for room DSL
- test flag, item and npc paired overlays

## Testing
- `cargo test -p amble_script`


------
https://chatgpt.com/codex/tasks/task_e_68bfa08af67c8324a59ba3708e708256