### PR TITLE
Add item DSL parsing and TOML emission

### DIFF
--- a/amble_script/README.md
+++ b/amble_script/README.md
@@ -58,3 +58,4 @@ Runs unit tests that parse the DSL and validate emitted TOML for triggers and ro
 
 - Trigger DSL guide: `docs/trigger_dsl_guide.md`
 - Rooms DSL guide: `docs/rooms_dsl_guide.md`
+- Items DSL guide: `docs/items_dsl_guide.md`

--- a/amble_script/docs/items_dsl_guide.md
+++ b/amble_script/docs/items_dsl_guide.md
@@ -1,0 +1,80 @@
+# Items DSL Guide
+
+This guide introduces the Items subset of the amble_script DSL and how it maps to the engine’s `items.toml`.
+
+Highlights:
+- Support for `name`, `desc`, `portable`, and `location` fields.
+- Optional `container state` (`open`, `closed`, `locked`, `transparentClosed`, `transparentLocked`).
+- Optional `text` field for readable items and `restricted` flag for non-droppable items.
+- `ability` entries compile to `[[items.abilities]]` tables with an optional `target`.
+
+## Minimal Item
+
+```
+item portal_gun {
+  name "Portal Gun"
+  desc "A device."
+  portable false
+  container state closed
+  location room portal-room
+  ability TurnOn
+}
+```
+
+Emits:
+
+```
+[[items]]
+id = "portal_gun"
+name = "Portal Gun"
+description = "A device."
+portable = false
+location = { Room = "portal-room" }
+container_state = "closed"
+
+[[items.abilities]]
+type = "TurnOn"
+```
+
+## Locations
+
+The `location` field places the item at start:
+
+```
+location inventory player   # player’s inventory
+location room portal-room   # in a room
+location npc clerk          # held by an NPC
+location chest strongbox    # inside a chest/container
+location nowhere "note"     # nowhere; note explains when it spawns
+```
+
+## Abilities
+
+Ability lines describe interactions or custom behaviors:
+
+```
+ability Read
+ability Unlock box
+```
+
+Each ability becomes an entry in `[[items.abilities]]` with `type` and optional `target`.
+
+## Optional Text & Restricted Items
+
+```
+text "Authorized personnel only."
+restricted true  # item cannot be dropped
+```
+
+`text` is emitted as the item’s readable text. `restricted` defaults to `false` and is only emitted when set to `true`.
+
+## Library Usage
+
+```
+use amble_script::{parse_items, compile_items_to_toml};
+let src = std::fs::read_to_string("items.amble")?;
+let items = parse_items(&src)?;
+let toml = compile_items_to_toml(&items)?;
+```
+
+The resulting `toml` string matches `amble_engine/data/items.toml`.

--- a/amble_script/src/grammar.pest
+++ b/amble_script/src/grammar.pest
@@ -114,7 +114,7 @@ triple_quoted = @{ "\"\"\"" ~ triple_char* ~ "\"\"\"" }
 single_quoted = @{ "'" ~ (escape | (!("\\" | "'") ~ ANY))* ~ "'" }
 string        = @{ triple_quoted | raw_quoted_h5 | raw_quoted_h4 | raw_quoted_h3 | raw_quoted_h2 | raw_quoted_h1 | raw_quoted | quoted | single_quoted }
 
-program = { SOI ~ (set_decl | trigger | room_def)+ ~ EOI }
+program = { SOI ~ (set_decl | trigger | room_def | item_def)+ ~ EOI }
 
 set_decl = { "let" ~ "set" ~ ident ~ "=" ~ set_list }
 set_list = { "(" ~ ident ~ ("," ~ ident)* ~ ")" }
@@ -296,3 +296,24 @@ overlay_presence_pair_block = { "{" ~ "present" ~ string ~ "absent" ~ string ~ "
 overlay_npc_states_stmt = { "overlay" ~ "if" ~ "npc" ~ ident ~ "here" ~ overlay_npc_states_block }
 overlay_npc_states_block = { "{" ~ overlay_npc_state_line+ ~ "}" }
 overlay_npc_state_line = { (ident ~ string) | ("custom" ~ "(" ~ ident ~ ")" ~ string) }
+
+// -----------------
+// Items
+// -----------------
+
+item_def     = { "item" ~ ident ~ item_block }
+item_block   = { "{" ~ (item_name | item_desc | item_portable | item_location | item_container_state | item_ability | item_text | item_restricted)* ~ "}" }
+item_name    = { "name" ~ string }
+item_desc    = { ("desc" | "description") ~ string }
+item_portable = { "portable" ~ boolean }
+item_location = { "location" ~ (inventory_loc | room_loc | npc_loc | chest_loc | nowhere_loc) }
+player_kw = { "player" }
+inventory_loc = { "inventory" ~ (ident | player_kw) }
+room_loc = { "room" ~ ident }
+npc_loc = { "npc" ~ ident }
+chest_loc = { "chest" ~ ident }
+nowhere_loc = { "nowhere" ~ string }
+item_container_state = { "container" ~ "state" ~ ("open" | "closed" | "locked" | "transparentClosed" | "transparentLocked" | "none") }
+item_ability = { "ability" ~ ident ~ ident? }
+item_text    = { "text" ~ string }
+item_restricted = { "restricted" ~ boolean }

--- a/amble_script/tests/fixtures/items_basic_three.toml
+++ b/amble_script/tests/fixtures/items_basic_three.toml
@@ -1,0 +1,29 @@
+# item no_cake (source line 1)
+[[items]]
+id = "no_cake"
+name = "No Cake"
+description = "Absence of cake."
+portable = true
+location = { Inventory = "player" }
+# item portal_gun (source line 8)
+[[items]]
+id = "portal_gun"
+name = "Portal Gun"
+description = "A device."
+portable = false
+location = { Room = "portal-room" }
+container_state = "closed"
+
+[[items.abilities]]
+type = "TurnOn"
+# item lost_and_found_key (source line 17)
+[[items]]
+id = "lost_and_found_key"
+name = "Lost and Found Key"
+description = "A small brass key."
+portable = true
+location = { Npc = "clerk" }
+
+[[items.abilities]]
+type = "Unlock"
+target = "box"

--- a/amble_script/tests/items_golden.rs
+++ b/amble_script/tests/items_golden.rs
@@ -1,0 +1,34 @@
+use amble_script::{compile_items_to_toml, parse_items};
+
+#[test]
+fn items_basic_golden() {
+    let src = r#"item no_cake {
+    name "No Cake"
+    desc "Absence of cake."
+    portable true
+    location inventory player
+}
+
+item portal_gun {
+    name "Portal Gun"
+    desc "A device."
+    portable false
+    container state closed
+    location room portal-room
+    ability TurnOn
+}
+
+item lost_and_found_key {
+    name "Lost and Found Key"
+    desc "A small brass key."
+    portable true
+    location npc clerk
+    ability Unlock box
+}
+"#;
+    let items = parse_items(src).expect("parse items ok");
+    assert_eq!(items.len(), 3);
+    let actual = compile_items_to_toml(&items).expect("compile ok");
+    let expected = include_str!("fixtures/items_basic_three.toml");
+    assert_eq!(actual.trim(), expected.trim());
+}


### PR DESCRIPTION
## Summary
- extend DSL grammar with `item` definitions and location/ability fields
- add `ItemAst` and `compile_items_to_toml` for emitting item data
- parse items via `parse_items` and cover with golden tests
- document item DSL and link guide from README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c3bca971188324b83a0ea8cbb24ec7