### PR TITLE
Add NPC parsing and compilation

### DIFF
--- a/amble_script/docs/npc_dsl_guide.md
+++ b/amble_script/docs/npc_dsl_guide.md
@@ -1,0 +1,86 @@
+# NPC DSL Guide
+
+This guide introduces the NPC subset of the amble_script DSL and how it maps to the engine's `npcs.toml`.
+
+Highlights:
+- Required fields: `name`, `desc`, `state`, and `location`.
+- Optional inventory with `inventory (item1, item2, ...)`.
+- `dialogue` block groups lines by state; use `custom(state)` for non‑named states.
+- Optional `movement` block describing automatic movement (`movement_type`, `rooms`, `timing`, optional `active` and `loop_route`).
+
+## Minimal NPC
+
+```amble
+npc receptionist {
+  name "Receptionist"
+  desc "A friendly face at the front desk."
+  state idle
+  location room lobby
+  dialogue {
+    idle { "Welcome!" }
+  }
+}
+```
+
+Emits:
+
+```toml
+[[npcs]]
+id = "receptionist"
+name = "Receptionist"
+description = "A friendly face at the front desk."
+state = "idle"
+
+[npcs.location]
+Room = "lobby"
+
+[npcs.dialogue]
+idle = ["Welcome!"]
+```
+
+## Dialogue
+
+Additional states can provide distinct lines. Use `custom(state)` when referencing custom states in triggers:
+
+```amble
+dialogue {
+  idle { "Welcome." }
+  busy { "One moment." }
+  custom(want-emitter) { "Have you found the emitter?" }
+}
+```
+
+In the emitted TOML, custom states are keyed as `custom:<state>`.
+
+## Inventory
+
+Give an NPC starting items:
+
+```amble
+inventory (badge, coffee)
+```
+
+## Movement
+
+NPCs may roam using a `movement` block:
+
+```amble
+movement {
+  movement_type route        # or "random"
+  rooms (lobby, break_room)
+  timing every_2_turns       # token from the engine's movement scheduler
+  active true                # optional; defaults to true
+  loop_route false           # optional when using "route"
+}
+```
+
+## Library Usage
+
+```rust
+use amble_script::{parse_npcs, compile_npcs_to_toml};
+let src = std::fs::read_to_string("npcs.amble")?;
+let npcs = parse_npcs(&src)?;
+let toml = compile_npcs_to_toml(&npcs)?;
+```
+
+The resulting `toml` string matches `amble_engine/data/npcs.toml`.

--- a/amble_script/src/grammar.pest
+++ b/amble_script/src/grammar.pest
@@ -80,6 +80,13 @@ keyword = {
   | "absent"
   | "custom"
   | "here"
+  | "dialogue"
+  | "inventory"
+  | "movement"
+  | "movement_type"
+  | "timing"
+  | "active"
+  | "loop_route"
   | // container state literals
   "closed"
   | "locked"
@@ -114,7 +121,7 @@ triple_quoted = @{ "\"\"\"" ~ triple_char* ~ "\"\"\"" }
 single_quoted = @{ "'" ~ (escape | (!("\\" | "'") ~ ANY))* ~ "'" }
 string        = @{ triple_quoted | raw_quoted_h5 | raw_quoted_h4 | raw_quoted_h3 | raw_quoted_h2 | raw_quoted_h1 | raw_quoted | quoted | single_quoted }
 
-program = { SOI ~ (set_decl | trigger | room_def | item_def)+ ~ EOI }
+program = { SOI ~ (set_decl | trigger | room_def | item_def | npc_def)+ ~ EOI }
 
 set_decl = { "let" ~ "set" ~ ident ~ "=" ~ set_list }
 set_list = { "(" ~ ident ~ ("," ~ ident)* ~ ")" }
@@ -317,3 +324,29 @@ item_container_state = { "container" ~ "state" ~ ("open" | "closed" | "locked" |
 item_ability = { "ability" ~ ident ~ ident? }
 item_text    = { "text" ~ string }
 item_restricted = { "restricted" ~ boolean }
+
+// -----------------
+// NPCs
+// -----------------
+
+npc_def    = { "npc" ~ ident ~ npc_block }
+npc_block  = { "{" ~ (npc_name | npc_desc | npc_location | npc_state | npc_dialogue | npc_inventory | npc_movement)* ~ "}" }
+npc_name   = { "name" ~ string }
+npc_desc   = { ("desc" | "description") ~ string }
+npc_location = { "location" ~ (room_loc | nowhere_loc) }
+npc_state  = { "state" ~ ident }
+npc_inventory = { "inventory" ~ "(" ~ ident ~ ("," ~ ident)* ~ ")" }
+
+npc_dialogue = { "dialogue" ~ "{" ~ (npc_dialogue_state | npc_dialogue_state_custom)+ ~ "}" }
+npc_dialogue_state = { ident ~ npc_dialogue_block }
+npc_dialogue_state_custom = { "custom" ~ "(" ~ ident ~ ")" ~ npc_dialogue_block }
+npc_dialogue_block = { "{" ~ string+ ~ "}" }
+
+npc_movement = { "movement" ~ movement_block }
+movement_block = { "{" ~ (movement_type_stmt | movement_rooms_stmt | movement_timing_stmt | movement_active_stmt | movement_loop_stmt)* ~ "}" }
+movement_type_stmt = { "movement_type" ~ movement_type_val }
+movement_type_val = { "route" | "random" }
+movement_rooms_stmt = { "rooms" ~ "(" ~ ident ~ ("," ~ ident)* ~ ")" }
+movement_timing_stmt = { "timing" ~ ident }
+movement_active_stmt = { "active" ~ boolean }
+movement_loop_stmt = { "loop_route" ~ boolean }

--- a/amble_script/src/main.rs
+++ b/amble_script/src/main.rs
@@ -82,7 +82,7 @@ fn run_compile(args: &[String]) {
         eprintln!("error: unable to read '{}': {}", &path, e);
         process::exit(1);
     });
-    let (asts, rooms, _items) = parse_program_full(&src).unwrap_or_else(|e| {
+    let (asts, rooms, _items, _npcs) = parse_program_full(&src).unwrap_or_else(|e| {
         eprintln!("parse error: {}", e);
         process::exit(1);
     });
@@ -248,7 +248,7 @@ fn lint_one_file(path: &str, world: &WorldRefs) -> usize {
             return 0;
         },
     };
-    let (asts, rooms_asts, _item_asts) = match parse_program_full(&src) {
+    let (asts, rooms_asts, _item_asts, _npc_asts) = match parse_program_full(&src) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("lint: parse error in '{}': {}", path, e);
@@ -861,7 +861,7 @@ fn fnv64(s: &str) -> u64 {
 
 fn flags_from_triggers_dsl(src: &str) -> HashSet<String> {
     let mut out = HashSet::new();
-    if let Ok((trigs, _rooms, _items)) = parse_program_full(src) {
+    if let Ok((trigs, _rooms, _items, _npcs)) = parse_program_full(src) {
         for t in trigs {
             collect_flags_from_actions_ast(&t.actions, &mut out);
         }

--- a/amble_script/tests/fixtures/npcs_roundtrip.toml
+++ b/amble_script/tests/fixtures/npcs_roundtrip.toml
@@ -1,0 +1,32 @@
+# npc black_knight (source line 1)
+[[npcs]]
+id = "black_knight"
+name = "The Black Knight"
+description = "A dark, glowering presence in a black suit of armor with a longsword."
+state = "normal"
+
+[npcs.location]
+Room = "sublevel-1-entrance"
+
+[npcs.dialogue]
+mad = ["Have at you!", "I'm invincible!", "'tis but a scratch.", "It's just a flesh wound!", "Come on, you pansy!", "Chicken! Bawk-bawk! Chicken!", "Gimme that sword back, or I'll bite your legs off!", "I won that sword in the office gift game. Give it back!"]
+normal = ["None shall pass.", "I move -- for no man.", "(He stands silently, blocking your path.)"]
+happy = ["None shall pa-- oh, no, you can go.", "YOU may pass, Candidate; I will be sure to dice anyone who dares to follow.", "You may pass, but beware and steer clear of Room AA-3B, should it reappear.", "Behold! (slices an aluminum can and then a tomato, laughing maniacally)"]
+# npc gonk_droid (source line 31)
+[[npcs]]
+id = "gonk_droid"
+name = "Gonk Droid"
+description = "A walking battery charger that looks like a trash bin."
+state = "normal"
+
+[npcs.location]
+Room = "main-lobby"
+
+[npcs.movement]
+movement_type = "route"
+rooms = ["main-lobby", "lift-bank-main", "lounge"]
+timing = "every_2_turns"
+
+[npcs.dialogue]
+normal = ["GONK!", "(gonk)", "GONK gonk.", "Gonk... Gonk..."]
+happy = ["(You hear a transformer humming a happy tune.)"]

--- a/amble_script/tests/npcs_golden.rs
+++ b/amble_script/tests/npcs_golden.rs
@@ -1,0 +1,63 @@
+use amble_script::{compile_npcs_to_toml, parse_npcs};
+
+#[test]
+fn npcs_basic_golden() {
+    let src = r#"npc black_knight {
+    name "The Black Knight"
+    desc "A dark, glowering presence in a black suit of armor with a longsword."
+    state normal
+    location room sublevel-1-entrance
+    dialogue {
+        mad {
+            "Have at you!"
+            "I'm invincible!"
+            "'tis but a scratch."
+            "It's just a flesh wound!"
+            "Come on, you pansy!"
+            "Chicken! Bawk-bawk! Chicken!"
+            "Gimme that sword back, or I'll bite your legs off!"
+            "I won that sword in the office gift game. Give it back!"
+        }
+        normal {
+            "None shall pass."
+            "I move -- for no man."
+            "(He stands silently, blocking your path.)"
+        }
+        happy {
+            "None shall pa-- oh, no, you can go."
+            "YOU may pass, Candidate; I will be sure to dice anyone who dares to follow."
+            "You may pass, but beware and steer clear of Room AA-3B, should it reappear."
+            "Behold! (slices an aluminum can and then a tomato, laughing maniacally)"
+        }
+    }
+}
+
+npc gonk_droid {
+    name "Gonk Droid"
+    desc "A walking battery charger that looks like a trash bin."
+    state normal
+    location room main-lobby
+    movement {
+        movement_type route
+        rooms (main-lobby, lift-bank-main, lounge)
+        timing every_2_turns
+    }
+    dialogue {
+        normal {
+            "GONK!"
+            "(gonk)"
+            "GONK gonk."
+            "Gonk... Gonk..."
+        }
+        happy {
+            "(You hear a transformer humming a happy tune.)"
+        }
+    }
+}
+"#;
+    let npcs = parse_npcs(src).expect("parse npcs ok");
+    assert_eq!(npcs.len(), 2);
+    let actual = compile_npcs_to_toml(&npcs).expect("compile ok");
+    let expected = include_str!("fixtures/npcs_roundtrip.toml");
+    assert_eq!(actual.trim(), expected.trim());
+}


### PR DESCRIPTION
## Summary
- extend DSL grammar to define NPCs
- parse and compile NPC data into TOML
- add golden tests for NPC round-trip
- document NPC syntax in new DSL guide

## Testing
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68c3c851bd44832481739582816a8ae1