### PR TITLE
Version bump to 0.58.0 Movement pauses added to NPC movement params.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "amble_engine"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "colored",

--- a/amble_engine/Cargo.toml
+++ b/amble_engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "amble_engine"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2024"
 
 [dependencies]

--- a/amble_engine/src/loader/npcs.rs
+++ b/amble_engine/src/loader/npcs.rs
@@ -164,6 +164,7 @@ impl RawNpcMovement {
             timing,
             active: self.active,
             last_moved_turn: 0,
+            paused_until: None,
         })
     }
 }

--- a/amble_engine/src/repl.rs
+++ b/amble_engine/src/repl.rs
@@ -238,8 +238,23 @@ pub fn check_npc_movement(world: &mut AmbleWorld, view: &mut View) -> Result<()>
     for npc_id in npc_ids {
         if let Some(npc) = world.npcs.get_mut(&npc_id) {
             if let Some(ref mut movement) = npc.movement {
+                // skip if NPC is inactive
                 if !movement.active {
                     continue;
+                }
+
+                // clear any set pause if expired
+                if let Some(resume_turn) = movement.paused_until {
+                    if current_turn >= resume_turn {
+                        info!("movement pause expiring for npc '{}': resuming activity", npc.symbol);
+                        movement.paused_until = None
+                    } else {
+                        info!(
+                            "npc '{}' is paused for player interaction, skipping movement check",
+                            npc.symbol
+                        );
+                        continue;
+                    }
                 }
 
                 if move_scheduled(movement, current_turn) {

--- a/amble_engine/src/repl/inventory.rs
+++ b/amble_engine/src/repl/inventory.rs
@@ -615,6 +615,8 @@ pub fn transfer_to_player(
         },
         VesselType::Npc => {
             if let Some(vessel) = world.npcs.get_mut(&vessel_id) {
+                // set a movement pause after taking something from NPC
+                vessel.pause_movement(world.turn_count, 4);
                 vessel.remove_item(loot_id);
             }
         },

--- a/amble_engine/src/repl/npc.rs
+++ b/amble_engine/src/repl/npc.rs
@@ -131,6 +131,11 @@ pub fn talk_to_handler(world: &mut AmbleWorld, view: &mut View, npc_name: &str) 
         return Ok(());
     };
 
+    // set a movement pause for 4 turns so NPC doesn't run off mid-interaction
+    if let Some(npc) = world.npcs.get_mut(&sent_id) {
+        npc.pause_movement(world.turn_count, 4);
+    }
+
     // check for any condition-specific dialogue
     let fired_triggers = check_triggers(world, view, &[TriggerCondition::TalkToNpc(sent_id)])?;
     let dialogue_fired = triggers_contain_condition(&fired_triggers, |cond| match cond {
@@ -225,6 +230,11 @@ pub fn give_to_npc_handler(world: &mut AmbleWorld, view: &mut View, item: &str, 
         entity_not_found(world, view, npc);
         return Ok(());
     };
+
+    // set a movement pause for 4 turns so NPC doesn't run off mid-interaction
+    if let Some(npc) = world.npcs.get_mut(&npc_id) {
+        npc.pause_movement(world.turn_count, 4);
+    }
 
     // find the target item in inventory, ensure it's portable, collect metadata
     let (item_id, item_name) =

--- a/amble_engine/tests/basic.rs
+++ b/amble_engine/tests/basic.rs
@@ -416,6 +416,7 @@ fn test_check_npc_movement() {
             timing: MovementTiming::EveryNTurns { turns: 1 },
             active: true,
             last_moved_turn: 0,
+            paused_until: None,
         }),
     };
     world.npcs.insert(npc_id, npc);


### PR DESCRIPTION
### Version to 0.58.0

#### NPC Movement Pauses Added
- **previously**: if NPC was scheduled to move right after player interacted with them, they'd leave and the player would have to chase them down
- **now**: npc-targeted commands (talk_to, take_from, give_to) set a 4 turn pause in NPC movement

#### Implementation:
- added `paused_until: Option<usize>`  to `NpcMovement` struct
- `repl::check_npc_movement()` clears expired pauses and skips movement checks on any NPC who is paused (or inactive, or has no movement configuration as before).
- `npc::move_scheduled()` returns false if `paused_until` is Some(_) _doesn't check turn number -- that's checked and cleared when appropriate in the repl function_
- added `Npc::pause_movement(current_turn, duration)` to simplify pausing an NPC from handler functions
- calls to `pause_movement()` added to the handlers for npc-targeted commands

#### Testing
cargo test --all -q -- all green
manually play-tested and logs checked -- works as intended
@codex review

