### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/pygmy-twylyte/amble/security/code-scanning/1](https://github.com/pygmy-twylyte/amble/security/code-scanning/1)

To fix this issue, an explicit `permissions` block should be added to `.github/workflows/rust.yml` to restrict the GITHUB_TOKEN privileges. Since the workflow only builds and tests the code and does not require write access to repository contents, the permission can be set to `contents: read`. This should be added at the root level of the workflow, immediately after the `name` and before the `on` and `jobs` definitions. No changes to imports or other code are necessary; just add the recommended block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
