### PR TITLE
:note DEV_MODE command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "tempfile",
  "textwrap",
  "thiserror 2.0.17",
+ "time",
  "toml",
  "uuid 1.17.0",
  "variantly",
@@ -333,6 +334,15 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -650,6 +660,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +740,12 @@ checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1117,6 +1139,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/amble_engine/Cargo.toml
+++ b/amble_engine/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0"
 textwrap = { version = "0.16.2", features = ["terminal_size"] }
 thiserror = "2.0.17"
+time = { version = "0.3.36", features = ["formatting"] }
 toml = "0.8.22"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 variantly = "0.4.0"

--- a/amble_engine/src/command.rs
+++ b/amble_engine/src/command.rs
@@ -73,6 +73,7 @@ pub enum Command {
     AdvanceSeq(String),
     ResetSeq(String),
     SetFlag(String),
+    DevNote(String),
     SpawnItem(String),
     StartSeq {
         // DEV_MODE only

--- a/amble_engine/src/repl.rs
+++ b/amble_engine/src/repl.rs
@@ -217,6 +217,7 @@ fn dispatch_command(command: &Command, world: &mut AmbleWorld, view: &mut View) 
         AdvanceSeq(seq_name) => dev_advance_seq_handler(world, view, seq_name),
         ResetSeq(seq_name) => dev_reset_seq_handler(world, view, seq_name),
         SetFlag(flag_name) => dev_set_flag_handler(world, view, flag_name),
+        DevNote(note) => dev_note_handler(world, view, note),
         StartSeq { seq_name, end } => dev_start_seq_handler(world, view, seq_name, end),
     }
     Ok(dr)

--- a/amble_engine/src/repl/input.rs
+++ b/amble_engine/src/repl/input.rs
@@ -38,6 +38,7 @@ const DEV_COMMANDS: &[&str] = &[
     ":schedule",
     ":schedule cancel",
     ":schedule delay",
+    ":note",
     ":teleport",
     ":port",
     ":spawn",
@@ -123,9 +124,10 @@ fn collect_grammar_terms() -> Vec<String> {
         if let Some(sequences) = literal_sequences(&rule.expr) {
             for seq in sequences {
                 if let Some(term) = normalize_sequence(&seq)
-                    && should_include(&term) {
-                        terms.push(term);
-                    }
+                    && should_include(&term)
+                {
+                    terms.push(term);
+                }
             }
         }
     }
@@ -368,9 +370,10 @@ impl RustylineInput {
 
         if let Some(path) = history_path.as_ref() {
             if let Some(dir) = path.parent()
-                && let Err(err) = fs::create_dir_all(dir) {
-                    warn!("failed to create history directory {}: {}", dir.display(), err);
-                }
+                && let Err(err) = fs::create_dir_all(dir)
+            {
+                warn!("failed to create history directory {}: {}", dir.display(), err);
+            }
 
             if let Err(err) = editor.load_history(path) {
                 match err {
@@ -395,9 +398,10 @@ impl RustylineInput {
                         warn!("failed to append to history: {err}");
                     }
                     if let Some(path) = self.history_path.as_ref()
-                        && let Err(err) = self.editor.save_history(path) {
-                            warn!("failed to persist history to {}: {}", path.display(), err);
-                        }
+                        && let Err(err) = self.editor.save_history(path)
+                    {
+                        warn!("failed to persist history to {}: {}", path.display(), err);
+                    }
                 }
                 Ok(InputEvent::Line(line))
             },

--- a/amble_engine/src/repl/system.rs
+++ b/amble_engine/src/repl/system.rs
@@ -265,6 +265,10 @@ pub fn help_handler(view: &mut View) {
                         description: "DEV: List upcoming scheduled events with due turn and notes.".into(),
                     },
                     HelpCommand {
+                        command: ":note <text>".into(),
+                        description: "DEV: Append a note to the daily dev log.".into(),
+                    },
+                    HelpCommand {
                         command: ":teleport <room_symbol>".into(),
                         description: "DEV: Instantly move to a room (alias :port).".into(),
                     },
@@ -339,6 +343,10 @@ pub fn help_handler_dev(view: &mut View) {
                 HelpCommand {
                     command: ":sched".into(),
                     description: "DEV: List upcoming scheduled events with due turn and notes.".into(),
+                },
+                HelpCommand {
+                    command: ":note <text>".into(),
+                    description: "DEV: Append a note to the daily dev log.".into(),
                 },
                 HelpCommand {
                     command: ":teleport <room_symbol>".into(),

--- a/amble_engine/src/save_files.rs
+++ b/amble_engine/src/save_files.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 pub const SAVE_DIR: &str = "saved_games";
+pub const LOG_DIR: &str = "logs";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SaveSlot {


### PR DESCRIPTION
This was straightforward, so Codex helped me crank it out quickly.
The ":note <note-text>" dev command appends anything after ":note" to a notes logfile with a time stamp, location, turn number and the note text. This makes it easy to note -- and find where content or engine changes need to be made. Here's a snippet from me walking through 2 rooms in Amble to test it:

```log
2025-12-22 05:21:13Z [NOTE] turn=152 room=lounge "Coffee Lounge" | hot coffee must be drinkable (and add health)
2025-12-22 05:22:13Z [NOTE] turn=153 room=lounge "Coffee Lounge" | better exit descriptions
2025-12-22 05:25:04Z [NOTE] turn=154 room=lounge "Coffee Lounge" | overlay still shows coffee machine ready to brew after coffee done
2025-12-22 05:32:17Z [NOTE] turn=160 room=portal-room "Portal Room" | HINT needed re getting battery charged
2025-12-22 05:33:44Z [NOTE] turn=164 room=lounge "Coffee Lounge" | hot_coffee should morph into cold_coffee after some turns
2025-12-22 05:38:16Z [NOTE] turn=175 room=portal-room "Portal Room" | awkward wording when gun fired "The wall in..." ... "... on the wall" is redundant
2025-12-22 05:38:56Z [NOTE] turn=176 room=portal-room "Portal Room" | change "portal" exit to "through the portal"```