### PR TITLE
Else clauses

### DIFF
--- a/amble_data/src/defs.rs
+++ b/amble_data/src/defs.rs
@@ -642,6 +642,8 @@ pub enum ActionKind {
     Conditional {
         condition: ConditionExpr,
         actions: Vec<ActionDef>,
+        #[serde(default)]
+        false_actions: Option<Vec<ActionDef>>,
     },
     ScheduleIn {
         turns_ahead: usize,

--- a/amble_data/src/validate.rs
+++ b/amble_data/src/validate.rs
@@ -562,10 +562,19 @@ fn validate_action(action: &ActionDef, ids: &IdSets<'_>, errors: &mut Vec<Valida
                 }
             }
         },
-        ActionKind::Conditional { condition, actions } => {
+        ActionKind::Conditional {
+            condition,
+            actions,
+            false_actions,
+        } => {
             validate_condition_expr(condition, ids, errors, context);
             for action in actions {
                 validate_action(action, ids, errors, context);
+            }
+            if let Some(false_actions) = false_actions {
+                for action in false_actions {
+                    validate_action(action, ids, errors, context);
+                }
             }
         },
         ActionKind::ScheduleIn { actions, .. } | ActionKind::ScheduleOn { actions, .. } => {

--- a/amble_engine/data/world.ron
+++ b/amble_engine/data/world.ron
@@ -70,6 +70,82 @@
     ),
     rooms: [
         (
+            id: "antechamber",
+            name: "Antechamber",
+            desc: "A circular waiting room lies beyond the Stargate, laid out with the solemn grandeur of a temple and the administrative cheer of a municipal licensing office. The floor is an intricate mosaic of sandals, vines, halos and what may simply be decorative punctuation. Two nearly identical doors stand opposite the gate, each trying very hard to look like the only reasonable choice a civilized soul could make. Between them, a brass [[item]]Directory Plaque[[/item]] and an overstuffed [[item]]Suggestion Box[[/item]] quietly imply that sectarian certainty requires a surprising amount of paperwork.",
+            visited: false,
+            exits: [
+                (
+                    direction: "through the stargate",
+                    to: "stargate-room",
+                    hidden: false,
+                    locked: false,
+                    required_flags: [],
+                    required_items: [],
+                    barred_message: None,
+                ),
+                (
+                    direction: "through the sandal-marked door",
+                    to: "shoe-shrine",
+                    hidden: false,
+                    locked: false,
+                    required_flags: [
+                        "sect-shoe",
+                    ],
+                    required_items: [],
+                    barred_message: Some("The sandal-marked door refuses to admit you. A tiny brass voice grille politely explains that access is restricted to the properly shod in spirit."),
+                ),
+                (
+                    direction: "through the gourd-marked door",
+                    to: "gourd-shrine",
+                    hidden: false,
+                    locked: false,
+                    required_flags: [
+                        "sect-gourd",
+                    ],
+                    required_items: [],
+                    barred_message: Some("The gourd-marked door remains shut. Somewhere within the woodwork, a mellow but disapproving silence suggests you lack sufficient cucurbit conviction."),
+                ),
+            ],
+            overlays: [
+                (
+                    conditions: [
+                        flagSet(
+                            flag: "sect-shoe",
+                        ),
+                    ],
+                    text: "The sandal-marked door seems calm, welcoming, and faintly superior. The gourd-marked door somehow manages to look judgmental despite being a vegetable-themed door.",
+                ),
+                (
+                    conditions: [
+                        flagSet(
+                            flag: "sect-gourd",
+                        ),
+                    ],
+                    text: "The gourd-marked door radiates a mellow autumnal confidence. The sandal-marked door has the air of something that would correct your posture while condemning your soul.",
+                ),
+            ],
+            scenery: [
+                (
+                    name: "Mosaic Floor",
+                    desc: Some("Thousands of tiny tiles depict worshippers arguing over footwear, produce, and the exact angle at which enlightenment ought to be shelved."),
+                ),
+                (
+                    name: "Twin Doors",
+                    desc: Some("One bears a carved sandal haloed in gold leaf; the other bears a plump gourd wreathed in vines. Each has the smug air of a doctrine that has won an argument with itself."),
+                ),
+                (
+                    name: "Ceiling Dome",
+                    desc: Some("The painted dome above shows a starry sky in which several constellations have been suspiciously redrawn to resemble either a sandal or a gourd, depending on where you stand and how willing you are to be persuaded."),
+                ),
+                (
+                    name: "Benches",
+                    desc: Some("Two padded benches line the wall beneath framed notices about reverence, queueing, and the inadvisability of starting comparative theology before lunch."),
+                ),
+            ],
+            scenery_default: None,
+        ),
+        (
             id: "aperture-lab",
             name: "Aperture Science Laboratory",
             desc: "The unnaturally white walls, floor, ceiling, even the air here feels clinical and overexposed. Everything hums at a frequency designed to encourage strict compliance. A few [[bright-red]]fire extinguishers[[/bright-red]] are scattered about, though there isn\'t any obvious source of ignition around. A very dated computer console glows green on a table beside a [[i]]highly[[/i]] over-engineered printer labeled [[hl]][[b]]Aperture|Amble Hospitality Generator[[/b]][[/hl]]. Across the room, a [[item]]vault-like door[[/item]] all but [[i]]demands[[/i]] attention.",
@@ -137,6 +213,9 @@
                     conditions: [
                         itemPresent(
                             item: "invitation",
+                        ),
+                        flagUnset(
+                            flag: "status:flash-blind",
                         ),
                     ],
                     text: "A glowing, steaming, sizzling invitation engraved on an asbestos sheet sits on the floor in front of the printer.",
@@ -283,6 +362,43 @@
             exits: [],
             overlays: [],
             scenery: [],
+            scenery_default: None,
+        ),
+        (
+            id: "gourd-shrine",
+            name: "Shrine of the Holy Gourd",
+            desc: "This chapel glows with warm amber light filtered through bottle-green glass, giving everything the reverent complexion of very expensive soup. Vines curl around fluted pillars, seed motifs repeat across the floor, and at the far end a circular [[item]]Harvest Altar[[/item]] stands beneath a domed canopy. A velvet-lined recess at its center is being guarded by atmosphere alone, which in this room seems to consider itself armed. The air smells of beeswax, autumn leaves, and the smug serenity of people who believe a vegetable solved the major philosophical questions decades ago.",
+            visited: false,
+            exits: [
+                (
+                    direction: "leave the shrine",
+                    to: "antechamber",
+                    hidden: false,
+                    locked: false,
+                    required_flags: [],
+                    required_items: [],
+                    barred_message: None,
+                ),
+            ],
+            overlays: [],
+            scenery: [
+                (
+                    name: "Stained Glass",
+                    desc: Some("Panels of heroic gourds float among stars, feed the multitudes, and in one especially ambitious scene appear to invent both ethics and seasonal decor."),
+                ),
+                (
+                    name: "Seed Mosaics",
+                    desc: Some("Tiny polished seeds have been pressed into the floor in elaborate spirals. They form sacred symbols, or possibly a diagram explaining how to make a very complicated tart."),
+                ),
+                (
+                    name: "Pews",
+                    desc: Some("Low benches arc toward the altar in a gentle crescent. Each kneeler is stuffed with something pleasantly springy that you suspect is either moss or doctrine."),
+                ),
+                (
+                    name: "Vines",
+                    desc: Some("Decorative vines wind up the pillars in careful symmetry. They are either carved wood or very disciplined plants."),
+                ),
+            ],
             scenery_default: None,
         ),
         (
@@ -494,19 +610,19 @@
             overlays: [
                 (
                     conditions: [
-                        itemPresent(
-                            item: "lebowski_rug",
+                        flagSet(
+                            flag: "found-portal-room",
                         ),
                     ],
-                    text: "An ornate, brick red rug lies in the center of the room and somehow -- really ties the room together.",
+                    text: "With the rug out of the way, the trap door found underneath opens to reveal a ladder down to a [[room]]hidden room[[/room]] below.",
                 ),
                 (
                     conditions: [
-                        itemAbsent(
-                            item: "lebowski_rug",
+                        flagUnset(
+                            flag: "found-portal-room",
                         ),
                     ],
-                    text: "The trap door opened in the floor reveals a ladder down to a hidden room below.",
+                    text: "An ornate, brick red [[item]]rug[[/item]] lies in the center of the room and somehow -- really ties the room together, man.",
                 ),
                 (
                     conditions: [
@@ -1057,6 +1173,43 @@
             scenery_default: None,
         ),
         (
+            id: "shoe-shrine",
+            name: "Shrine of the Holy Shoe",
+            desc: "A long, narrow chapel of polished oak and stern symmetry stretches before you, lit by stained glass windows that cast sandal-shaped colors across the floor. At the far end, on a raised [[item]]Sandal Altar[[/item]], a velvet-lined recess sits at attention beneath a cone of buttery light. Rows of pews face forward with the crisp obedience of well-behaved feet. The air carries beeswax, old leather, and the faint, intoxicating scent of absolute certainty rubbed to a shine.",
+            visited: false,
+            exits: [
+                (
+                    direction: "leave the shrine",
+                    to: "antechamber",
+                    hidden: false,
+                    locked: false,
+                    required_flags: [],
+                    required_items: [],
+                    barred_message: None,
+                ),
+            ],
+            overlays: [],
+            scenery: [
+                (
+                    name: "Stained Glass",
+                    desc: Some("The windows depict the Sacred Sandal performing small but decisive miracles: crossing deserts, toppling heretics, and in one panel apparently inventing left and right."),
+                ),
+                (
+                    name: "Pews",
+                    desc: Some("Straight-backed pews stand in impeccable rows. The kneelers are shaped with orthopedic conviction."),
+                ),
+                (
+                    name: "Polished Floor",
+                    desc: Some("The boards gleam so brightly you can see your reflection looking slightly more devout than usual."),
+                ),
+                (
+                    name: "Censers",
+                    desc: Some("Brass censers hang from the rafters, swinging very slightly and releasing a fragrance halfway between incense and a cobbler\'s workshop."),
+                ),
+            ],
+            scenery_default: None,
+        ),
+        (
             id: "stargate-room",
             name: "Stargate Room",
             desc: "A hangar-size concrete room, connected to the Aperture lab through a huge, round vault door. Little light reaches the darkened corners of the room, but at its center stands a round control console in a crossfire of floodligts and ringed with [[b]]strange symbols[[/b]]. A giant metallic ring festooned with similar symbols stands on end at the end of the room.\n\nThere are three large buttons in the center of the console:",
@@ -1120,6 +1273,33 @@
                         ),
                     ],
                     text: "On the right, shaped like a fork:       [[red]][[dimmed]]sunken[[/dimmed]][[/red]]",
+                ),
+                (
+                    conditions: [
+                        flagSet(
+                            flag: "sect-gourd",
+                        ),
+                    ],
+                    text: "Underneath, shaped like a fish:         [[green]]RAISED[[/green]]",
+                ),
+                (
+                    conditions: [
+                        flagSet(
+                            flag: "sect-shoe",
+                        ),
+                    ],
+                    text: "Underneath, shaped like a fish:         [[green]]RAISED[[/green]]",
+                ),
+                (
+                    conditions: [
+                        flagUnset(
+                            flag: "sect-gourd",
+                        ),
+                        flagUnset(
+                            flag: "sect-shoe",
+                        ),
+                    ],
+                    text: "Underneath, shaped like a fish:         [[red]][[dimmed]]sunken[[/dimmed]][[/red]]",
                 ),
             ],
             scenery: [
@@ -2928,8 +3108,8 @@
         ),
         (
             id: "gonk_family_photo",
-            name: "Gonk\'s Family Photo",
-            desc: "A slightly scorched photograph of the gonk droid with its family: a PC power supply, a D-cell, and a set of adorable AAA triplets.",
+            name: "Fading Photograph",
+            desc: "A slightly scorched and faded photograph depicts the gonk droid with its family: a PC power supply, a D-cell, and a set of adorable AAA triplets.",
             movability: free,
             container_state: None,
             location: Npc("gonk_droid"),
@@ -2990,7 +3170,9 @@
             container_state: None,
             location: Nowhere,
             visibility: listed,
-            visible_when: None,
+            visible_when: Some(Pred(missingFlag(
+                flag: "status:flash-blind",
+            ))),
             aliases: [],
             abilities: [
                 read,
@@ -3024,7 +3206,9 @@
             container_state: None,
             location: Nowhere,
             visibility: listed,
-            visible_when: None,
+            visible_when: Some(Pred(missingFlag(
+                flag: "status:flash-blind",
+            ))),
             aliases: [],
             abilities: [
                 read,
@@ -3033,6 +3217,25 @@
                 handle: insulate,
             },
             text: Some("Candidate #2112-42:\nYou are cordially invited to complete your evaluation and induction. Please present this invitation at the Amble Adventures office immediately upon arrival."),
+            consumable: None,
+        ),
+        (
+            id: "purple_vision_blob",
+            name: "Scintillating Purple Blob",
+            desc: "A pretty violet blob flashed into your central vision by the PlasmaJet printer.",
+            movability: fixed(
+                reason: "It\'s an optical illusion. Hopefully temporary.",
+            ),
+            container_state: None,
+            location: Room("aperture-lab"),
+            visibility: listed,
+            visible_when: Some(Pred(hasFlag(
+                flag: "status:flash-blind",
+            ))),
+            aliases: [],
+            abilities: [],
+            interaction_requires: {},
+            text: None,
             consumable: None,
         ),
         (
@@ -3070,6 +3273,49 @@
             consumable: None,
         ),
         (
+            id: "sect_directory_plaque",
+            name: "Directory Plaque",
+            desc: "A polished brass plaque mounted between the two inner doors.",
+            movability: fixed(
+                reason: "It is bolted to the wall with ecumenical firmness.",
+            ),
+            container_state: None,
+            location: Room("antechamber"),
+            visibility: scenery,
+            visible_when: None,
+            aliases: [
+                "plaque",
+                "directory",
+            ],
+            abilities: [
+                read,
+            ],
+            interaction_requires: {},
+            text: Some("[[box:WAYFINDING FOR THE DEVOUT]]\nLeft of Certainty ........ Shrine of the Holy Shoe\nRight of Certainty ....... Shrine of the Holy Gourd\nStraight Back ............ Stargate / Unscheduled Transcendence\n\n[[center]][[i]]Please keep doctrinal disputes below a resonant chanting level.[[/i]][[/center]]"),
+            consumable: None,
+        ),
+        (
+            id: "schism_suggestion_box",
+            name: "Suggestion Box",
+            desc: "An oak suggestion box with two slots labeled [[i]]Constructive Feedback[[/i]] and [[i]]Vindictive Denunciation[[/i]]. The second slot is much more worn.",
+            movability: fixed(
+                reason: "It is chained to a pedestal, presumably after an incident.",
+            ),
+            container_state: None,
+            location: Room("antechamber"),
+            visibility: scenery,
+            visible_when: None,
+            aliases: [
+                "box",
+            ],
+            abilities: [
+                read,
+            ],
+            interaction_requires: {},
+            text: Some("[[box:SUGGESTION BOX GUIDELINES]]\n1. Keep notes brief, legible, and only moderately anathematizing.\n2. Do not submit produce.\n3. Do not submit footwear.\n4. Do not submit produce about footwear.\n5. Complaints concerning the nonbeliever observation room will be accepted once reality catches up."),
+            consumable: None,
+        ),
+        (
             id: "apple_lab_pc",
             name: "Apple ][+",
             desc: "An ancient, 8-bit Apple ][+ computer complete with monochrome CRT character display, and inexplicably hard-wired into the [[i]]bleeding edge[[/i]] plasma-jet printer nearby.",
@@ -3079,7 +3325,9 @@
             container_state: None,
             location: Room("aperture-lab"),
             visibility: scenery,
-            visible_when: None,
+            visible_when: Some(Pred(missingFlag(
+                flag: "status:flash-blind",
+            ))),
             aliases: [
                 "pc",
                 "console",
@@ -3120,7 +3368,9 @@
             container_state: None,
             location: Room("aperture-lab"),
             visibility: listed,
-            visible_when: None,
+            visible_when: Some(Pred(missingFlag(
+                flag: "status:flash-blind",
+            ))),
             aliases: [
                 "magnifier",
             ],
@@ -3139,7 +3389,9 @@
             container_state: Some(open),
             location: Room("aperture-lab"),
             visibility: listed,
-            visible_when: None,
+            visible_when: Some(Pred(missingFlag(
+                flag: "status:flash-blind",
+            ))),
             aliases: [
                 "status",
                 "screen",
@@ -3248,6 +3500,66 @@
             consumable: None,
         ),
         (
+            id: "gourd_hymn_board",
+            name: "Hymn Board",
+            desc: "A carved wooden board displays the order of service in tidy movable letters.",
+            movability: fixed(
+                reason: "It is mounted securely to the wall.",
+            ),
+            container_state: None,
+            location: Room("gourd-shrine"),
+            visibility: scenery,
+            visible_when: None,
+            aliases: [
+                "board",
+                "hymn board",
+            ],
+            abilities: [
+                read,
+            ],
+            interaction_requires: {},
+            text: Some("[[box:ORDER OF MELLOW EXULTATION]]\nOpening Chant ............ O Round and Plentiful One\nResponsive Reading ....... Seeds of Wisdom, Verses 4-12\nMeditation ............... On the Folly of Single Sandals\nClosing Hymn ............. Abide With Gourd\n\n[[center]][[i]]Latecomers may join in at whatever verse feels spiritually seasonal.[[/i]][[/center]]"),
+            consumable: None,
+        ),
+        (
+            id: "harvest_altar",
+            name: "Harvest Altar",
+            desc: "A circular altar of polished wood and green stone. Its center holds a velvet-lined niche clearly reserved for an Object of Great Significance, or at least an Object prepared to put up with a great deal of incense.",
+            movability: fixed(
+                reason: "It appears to weigh slightly more than piety.",
+            ),
+            container_state: None,
+            location: Room("gourd-shrine"),
+            visibility: scenery,
+            visible_when: None,
+            aliases: [
+                "altar",
+            ],
+            abilities: [],
+            interaction_requires: {},
+            text: None,
+            consumable: None,
+        ),
+        (
+            id: "seed_abacus",
+            name: "Seed Abacus",
+            desc: "A brass frame strung with lacquered seeds. It seems to be used for counting prayers, blessings, or casserole attendees.",
+            movability: fixed(
+                reason: "It is attached to a stand that looks rooted in theology.",
+            ),
+            container_state: None,
+            location: Room("gourd-shrine"),
+            visibility: scenery,
+            visible_when: None,
+            aliases: [
+                "abacus",
+            ],
+            abilities: [],
+            interaction_requires: {},
+            text: None,
+            consumable: None,
+        ),
+        (
             id: "aa_3_button_main",
             name: "[AA-3] Button (Unlit)",
             desc: "The button to send the elevator to sublevel AA-3, currently unlit and disabled.",
@@ -3299,11 +3611,13 @@
             visibility: scenery,
             visible_when: None,
             aliases: [],
-            abilities: [],
+            abilities: [
+                read,
+            ],
             interaction_requires: {
                 burn: ignite,
             },
-            text: None,
+            text: Some("[[box]]Property of Maude Lebowski[[/box]]"),
             consumable: None,
         ),
         (
@@ -3639,6 +3953,87 @@
             ],
             interaction_requires: {},
             text: Some("    Zaphod B............................ happy hour\n    Marvin (ugh, not again)............. teatime\n    Candidate (#2112-42) ............... (overdue)\n    Jenkins the Time Ferret............. (last Thursday)\n\nThere\'s a smudged doodle of a blinding sun and a stylish pair of sunglasses next to the list for patio seating."),
+            consumable: None,
+        ),
+        (
+            id: "shoe_liturgy_board",
+            name: "Liturgy Board",
+            desc: "A mahogany board lists the day\'s readings and hymns in severe gold letters.",
+            movability: fixed(
+                reason: "It is affixed with screws that look doctrinally approved.",
+            ),
+            container_state: None,
+            location: Room("shoe-shrine"),
+            visibility: scenery,
+            visible_when: None,
+            aliases: [
+                "board",
+                "liturgy board",
+                "hymn board",
+            ],
+            abilities: [
+                read,
+            ],
+            interaction_requires: {},
+            text: Some("[[box:ORDER OF SOLEMN OBSERVANCE]]\nOpening Processional ..... Tread Lightly, Yet With Conviction\nReading .................. The Book of Arch Support, Chapter 3\nHomily ................... On the Error of Overvaluing Produce\nClosing Hymn ............. Guide Me, O Thou Great Sandal\n\n[[center]][[i]]Please keep both feet pointed toward the altar during moments of revelation.[[/i]][[/center]]"),
+            consumable: None,
+        ),
+        (
+            id: "sandal_altar",
+            name: "Sandal Altar",
+            desc: "A lacquered wooden altar trimmed in brass. At its center rests a velvet-lined recess shaped for an article of singular sacred importance, patiently awaiting either revelation or a careful dusting.",
+            movability: fixed(
+                reason: "It is solid, immovable, and plainly in favor of arch support.",
+            ),
+            container_state: None,
+            location: Room("shoe-shrine"),
+            visibility: scenery,
+            visible_when: None,
+            aliases: [
+                "altar",
+            ],
+            abilities: [],
+            interaction_requires: {},
+            text: None,
+            consumable: None,
+        ),
+        (
+            id: "heel_the_poor_fund",
+            name: "Heel the Poor Fund",
+            desc: "A brass donation box polished to missionary brightness. The slot is worn smooth by generations of charitable guilt.",
+            movability: fixed(
+                reason: "It is locked, weighted, and probably insured.",
+            ),
+            container_state: None,
+            location: Room("shoe-shrine"),
+            visibility: scenery,
+            visible_when: None,
+            aliases: [
+                "donation box",
+                "fund",
+            ],
+            abilities: [
+                read,
+            ],
+            interaction_requires: {},
+            text: Some("[[box]]HEEL THE POOR[[/box]][[center]][[i]]Loose change gladly accepted. Tight change accepted with gentle disappointment.[[/i]][[/center]]"),
+            consumable: None,
+        ),
+        (
+            id: "sect_gate_button",
+            name: "[ Fish ]",
+            desc: "A stylized, fish-shaped icon adorns this button. It\'s a little smaller than the other buttons, placed quietly out of the way, and seems almost like the designer of the Stargate control didn\'t want to include it at all.",
+            movability: fixed(
+                reason: "It\'s part of the Stargate control console.",
+            ),
+            container_state: None,
+            location: Room("stargate-room"),
+            visibility: listed,
+            visible_when: None,
+            aliases: [],
+            abilities: [],
+            interaction_requires: {},
+            text: None,
             consumable: None,
         ),
         (
@@ -5015,7 +5410,7 @@
         ),
         (
             id: "messiah_gourd",
-            name: "Gourd",
+            name: "The Messiah\'s Gourd",
             desc: "A grapefruit-sized, tan gourd. It rattles a little when you shake it.",
             movability: free,
             container_state: None,
@@ -5030,7 +5425,7 @@
         ),
         (
             id: "messiah_shoe",
-            name: "Shoe",
+            name: "The Messiah\'s Shoe",
             desc: "A single, worn leather sandal of untold age. [[i]]Something appears to be scratched into the sole.[[/i]]",
             movability: free,
             container_state: None,
@@ -5141,7 +5536,9 @@
             visible_when: Some(Pred(hasFlag(
                 flag: "sect-gourd",
             ))),
-            aliases: [],
+            aliases: [
+                "handwritten note",
+            ],
             abilities: [
                 read,
             ],
@@ -5446,20 +5843,20 @@
             id: "demerzel",
             name: "Demerzel",
             desc: "A sharply dressed android sitting at the reception desk.\n\nDemerzel is a positronic android, and has been continuously online for thousands of years -- working at reception desks going back as far as Pharoah Ramses II. At her position at Amble Adentures, she also serves as a firewall, preventing any clearly unworthy Candidates from making any progress through the system.",
-            max_hp: 20,
+            max_hp: 200,
             location: Room("amble-office"),
-            state: normal,
+            state: custom("unhelpful"),
             dialogue: {
-                bored: [
-                    "Impressive work, getting the keycard. Many of our previous applicants have died in the attempt. Very promising! The evaluator will be pleased. Strong lateral thinking and slight psychosis are essential for such a dangerous position, as I\'m sure you are aware.",
-                    "You can now use the elevator to find room AA-3B for the next stage of your initiation.",
-                ],
-                happy: [
+                custom("helpful"): [
                     "Terribly sorry to report that we are in a bit of trouble here today. The last candidate was inconsiderate enough to take the elevator access card into the poetry panic room just before he melted, and we can\'t retrieve it.",
                     "The elevator keycard last pinged our system from the Poetry Panic Room, but it is sealed, and concealed behind the whiteboard. Only the Poetry Performer Unit can grant access.",
                     "Sorry I didn\'t immediately recognize that you are a Candidate, but most of your competitors have been blurry, furry, or out of phase.",
                 ],
-                normal: [
+                custom("impressed"): [
+                    "Impressive work, getting the keycard. Many of our previous applicants have died in the attempt. Very promising! The evaluator will be pleased. Strong lateral thinking and slight psychosis are essential for such a dangerous position, as I\'m sure you are aware.",
+                    "You can now use the elevator to find room AA-3B for the next stage of your initiation.",
+                ],
+                custom("unhelpful"): [
                     "(She rolls her eyes.) Please wait quietly out of the way. There are people with invitations who should be assisted first.",
                     "(She simply ignores you.)",
                     "(She continues doing her job -- which appears to be pointedly ignoring anyone without an invitation.)",
@@ -7059,9 +7456,53 @@
                     priority: None,
                 ),
                 (
-                    action: awardPoints(
-                        amount: 5,
-                        reason: "Traded the Initech mug for HAL\'s third module",
+                    action: conditional(
+                        condition: Pred(flagInProgress(
+                            flag: "hal-reboot",
+                        )),
+                        actions: [
+                            (
+                                action: awardPoints(
+                                    amount: 5,
+                                    reason: "Traded the Initech mug for HAL\'s third module",
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        false_actions: Some([
+                            (
+                                action: awardPoints(
+                                    amount: 5,
+                                    reason: "Traded the Initech mug for some electronic gizmo.",
+                                ),
+                                priority: None,
+                            ),
+                        ]),
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[Gonk Droid] Photo Taken",
+            note: None,
+            only_once: false,
+            event: takeFromNpc(
+                item: "gonk_family_photo",
+                npc: "gonk_droid",
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: showMessage(
+                        text: "The gonk droid excitedly points out something on the photograph. Or would, if it had anything to point with.",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: npcSays(
+                        npc: "gonk_droid",
+                        quote: "Gonk! →",
                     ),
                     priority: None,
                 ),
@@ -7070,7 +7511,35 @@
         (
             name: "[Gonk Droid] Happy When Family Photo Inspected",
             note: None,
-            only_once: true,
+            only_once: false,
+            event: lookAtItem(
+                item: "gonk_family_photo",
+            ),
+            conditions: Pred(missingFlag(
+                flag: "made-gonk-proud",
+            )),
+            actions: [
+                (
+                    action: awardPoints(
+                        amount: 2,
+                        reason: "Admired the gonk droid\'s family photo",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: addFlag(
+                        flag: simple(
+                            name: "made-gonk-proud",
+                        ),
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[Gonk Droid] Happy When Family Photo Inspected",
+            note: None,
+            only_once: false,
             event: lookAtItem(
                 item: "gonk_family_photo",
             ),
@@ -7086,21 +7555,6 @@
                 (
                     action: showMessage(
                         text: "The gonk droid totters with pride as you view its family photo.",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: awardPoints(
-                        amount: 2,
-                        reason: "Admired the gonk droid\'s family photo",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: addFlag(
-                        flag: simple(
-                            name: "made-gonk-proud",
-                        ),
                     ),
                     priority: None,
                 ),
@@ -7151,7 +7605,7 @@
                 (
                     action: setNpcState(
                         npc: "demerzel",
-                        state: normal,
+                        state: custom("unhelpful"),
                     ),
                     priority: None,
                 ),
@@ -7177,7 +7631,7 @@
                 (
                     action: setNpcState(
                         npc: "demerzel",
-                        state: happy,
+                        state: custom("helpful"),
                     ),
                     priority: None,
                 ),
@@ -7223,7 +7677,7 @@
                 (
                     action: setNpcState(
                         npc: "demerzel",
-                        state: happy,
+                        state: custom("helpful"),
                     ),
                     priority: None,
                 ),
@@ -7316,85 +7770,6 @@
             ],
         ),
         (
-            name: "[HINT Radio] Find/Insert Vogon Poetry",
-            note: None,
-            only_once: true,
-            event: giveToNpc(
-                item: "invitation",
-                npc: "demerzel",
-            ),
-            conditions: All([]),
-            actions: [
-                (
-                    action: scheduleInIf(
-                        turns_ahead: 3,
-                        condition: Any([
-                            All([
-                                Pred(hasItem(
-                                    item: "hint_radio",
-                                )),
-                                Pred(hasFlag(
-                                    flag: "hint-radio-on",
-                                )),
-                                Pred(missingFlag(
-                                    flag: "panic-room-open",
-                                )),
-                                Any([
-                                    Pred(playerInRoom(
-                                        room: "amble-office",
-                                    )),
-                                    Pred(playerInRoom(
-                                        room: "vip-bathroom",
-                                    )),
-                                ]),
-                            ]),
-                            Pred(hasFlag(
-                                flag: "panic-room-open",
-                            )),
-                        ]),
-                        on_false: retryNextTurn,
-                        actions: [
-                            (
-                                action: conditional(
-                                    condition: All([
-                                        Pred(hasItem(
-                                            item: "hint_radio",
-                                        )),
-                                        Pred(hasFlag(
-                                            flag: "hint-radio-on",
-                                        )),
-                                        Pred(missingFlag(
-                                            flag: "panic-room-open",
-                                        )),
-                                        Any([
-                                            Pred(playerInRoom(
-                                                room: "amble-office",
-                                            )),
-                                            Pred(playerInRoom(
-                                                room: "vip-bathroom",
-                                            )),
-                                        ]),
-                                    ]),
-                                    actions: [
-                                        (
-                                            action: npcSays(
-                                                npc: "hint_radio_npc",
-                                                quote: "The rumor around here is that the last candidate was vaporized while sealed in the hidden Poetry Panic Room at the office, and they had the sole remaining elevator keycard with them. The Poetry Performer will panic if you try to make it perform some Vogon poetry. I\'m sure you see where this is going.",
-                                            ),
-                                            priority: None,
-                                        ),
-                                    ],
-                                ),
-                                priority: None,
-                            ),
-                        ],
-                        note: Some("poetry performer radio hint"),
-                    ),
-                    priority: None,
-                ),
-            ],
-        ),
-        (
             name: "[Poetry-Panic] Acquired Elevator Keycard",
             note: None,
             only_once: true,
@@ -7406,7 +7781,7 @@
                 (
                     action: setNpcState(
                         npc: "demerzel",
-                        state: bored,
+                        state: custom("impressed"),
                     ),
                     priority: None,
                 ),
@@ -7544,132 +7919,124 @@
             ],
         ),
         (
-            name: "[Aperture-Lab] Printer Loaded",
+            name: "[Aperture-Lab] Printer Loaded (paper)",
             note: Some("change printer display when paper inserted"),
             only_once: false,
             event: insertItemInto(
                 item: "printer_paper",
                 container: "lab_printer",
             ),
-            conditions: Pred(hasFlag(
-                flag: "got-invitation",
-            )),
+            conditions: All([]),
             actions: [
                 (
-                    action: modifyItem(
-                        item: "lab_printer",
-                        patch: (
-                            name: None,
-                            desc: None,
-                            text: Some("0 JOB(S) PENDING"),
-                            movability: None,
-                            container_state: None,
-                            remove_container_state: false,
-                            visibility: None,
-                            visible_when: None,
-                            aliases: None,
-                            add_abilities: [],
-                            remove_abilities: [],
-                        ),
+                    action: conditional(
+                        condition: Pred(hasFlag(
+                            flag: "got-invitation",
+                        )),
+                        actions: [
+                            (
+                                action: modifyItem(
+                                    item: "lab_printer",
+                                    patch: (
+                                        name: None,
+                                        desc: None,
+                                        text: Some("0 JOB(S) PENDING"),
+                                        movability: None,
+                                        container_state: None,
+                                        remove_container_state: false,
+                                        visibility: None,
+                                        visible_when: None,
+                                        aliases: None,
+                                        add_abilities: [],
+                                        remove_abilities: [],
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        false_actions: Some([
+                            (
+                                action: modifyItem(
+                                    item: "lab_printer",
+                                    patch: (
+                                        name: None,
+                                        desc: None,
+                                        text: Some("1 JOB(S) PENDING"),
+                                        movability: None,
+                                        container_state: None,
+                                        remove_container_state: false,
+                                        visibility: None,
+                                        visible_when: None,
+                                        aliases: None,
+                                        add_abilities: [],
+                                        remove_abilities: [],
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                        ]),
                     ),
                     priority: None,
                 ),
             ],
         ),
         (
-            name: "[Aperture-Lab] Printer Loaded",
-            note: Some("change printer display when paper inserted"),
-            only_once: false,
-            event: insertItemInto(
-                item: "printer_paper",
-                container: "lab_printer",
-            ),
-            conditions: Pred(missingFlag(
-                flag: "got-invitation",
-            )),
-            actions: [
-                (
-                    action: modifyItem(
-                        item: "lab_printer",
-                        patch: (
-                            name: None,
-                            desc: None,
-                            text: Some("1 JOB(S) PENDING"),
-                            movability: None,
-                            container_state: None,
-                            remove_container_state: false,
-                            visibility: None,
-                            visible_when: None,
-                            aliases: None,
-                            add_abilities: [],
-                            remove_abilities: [],
-                        ),
-                    ),
-                    priority: None,
-                ),
-            ],
-        ),
-        (
-            name: "[Aperture-Lab] Printer Loaded",
+            name: "[Aperture-Lab] Printer Loaded (asbestos)",
             note: Some("change printer display when asbestos sheet inserted"),
             only_once: false,
             event: insertItemInto(
                 item: "asbestos_sheet",
                 container: "lab_printer",
             ),
-            conditions: Pred(hasFlag(
-                flag: "got-invitation",
-            )),
+            conditions: All([]),
             actions: [
                 (
-                    action: modifyItem(
-                        item: "lab_printer",
-                        patch: (
-                            name: None,
-                            desc: None,
-                            text: Some("0 JOB(S) PENDING"),
-                            movability: None,
-                            container_state: None,
-                            remove_container_state: false,
-                            visibility: None,
-                            visible_when: None,
-                            aliases: None,
-                            add_abilities: [],
-                            remove_abilities: [],
-                        ),
-                    ),
-                    priority: None,
-                ),
-            ],
-        ),
-        (
-            name: "[Aperture-Lab] Printer Loaded",
-            note: Some("change printer display when asbestos sheet inserted"),
-            only_once: false,
-            event: insertItemInto(
-                item: "asbestos_sheet",
-                container: "lab_printer",
-            ),
-            conditions: Pred(missingFlag(
-                flag: "got-invitation",
-            )),
-            actions: [
-                (
-                    action: modifyItem(
-                        item: "lab_printer",
-                        patch: (
-                            name: None,
-                            desc: None,
-                            text: Some("1 JOB(S) PENDING"),
-                            movability: None,
-                            container_state: None,
-                            remove_container_state: false,
-                            visibility: None,
-                            visible_when: None,
-                            aliases: None,
-                            add_abilities: [],
-                            remove_abilities: [],
-                        ),
+                    action: conditional(
+                        condition: Pred(hasFlag(
+                            flag: "got-invitation",
+                        )),
+                        actions: [
+                            (
+                                action: modifyItem(
+                                    item: "lab_printer",
+                                    patch: (
+                                        name: None,
+                                        desc: None,
+                                        text: Some("0 JOB(S) PENDING"),
+                                        movability: None,
+                                        container_state: None,
+                                        remove_container_state: false,
+                                        visibility: None,
+                                        visible_when: None,
+                                        aliases: None,
+                                        add_abilities: [],
+                                        remove_abilities: [],
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        false_actions: Some([
+                            (
+                                action: modifyItem(
+                                    item: "lab_printer",
+                                    patch: (
+                                        name: None,
+                                        desc: None,
+                                        text: Some("1 JOB(S) PENDING"),
+                                        movability: None,
+                                        container_state: None,
+                                        remove_container_state: false,
+                                        visibility: None,
+                                        visible_when: None,
+                                        aliases: None,
+                                        add_abilities: [],
+                                        remove_abilities: [],
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                        ]),
                     ),
                     priority: None,
                 ),
@@ -7707,145 +8074,225 @@
             ],
         ),
         (
-            name: "[Aperture-Lab] Printer Burns Paper",
+            name: "[Aperture-Lab] PlasmaJet Used",
             note: None,
             only_once: false,
             event: useItem(
                 item: "lab_printer",
                 ability: turnOn,
             ),
-            conditions: Pred(containerHasItem(
-                container: "lab_printer",
-                item: "printer_paper",
-            )),
+            conditions: All([]),
             actions: [
                 (
-                    action: despawnItem(
-                        item: "printer_paper",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: addFlag(
-                        flag: simple(
-                            name: "burned-invitation",
-                        ),
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: spawnItemInRoom(
-                        item: "flaming_invitation",
-                        room: "aperture-lab",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: scheduleIn(
-                        turns_ahead: 5,
-                        actions: [
-                            (
-                                action: replaceItem(
-                                    old_item: "flaming_invitation",
-                                    new_item: "charred_invitation_bits",
-                                ),
-                                priority: None,
-                            ),
-                        ],
-                        note: Some("invitation finishes burning"),
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: addSpinnerWedge(
-                        spinner: "ambientInterior",
-                        text: "An annoyed voice on the PA: ATTENTION Staff - do NOT use regular copy paper in the lab PlasmaJet printer, or we will be shut down again -- by order of FEMA, PETA, the ATF, FBI, and our HOA.",
-                        width: 1,
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: showMessage(
-                        text: "The paper ignites in a flash, and the PlasmaJet spits a flaming document on the floor at your feet.",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: scheduleIn(
-                        turns_ahead: 2,
+                    action: conditional(
+                        condition: Pred(containerHasItem(
+                            container: "lab_printer",
+                            item: "printer_paper",
+                        )),
                         actions: [
                             (
                                 action: showMessage(
-                                    text: "A nearby smoke detector alarms briefly, the quits with an exasperated sigh when it sees you near the PlasmaJet printer, figuring you get what you deserve.",
+                                    text: "The paper ignites in an instant, and the PlasmaJet spits a flaming document on the floor at your feet.",
                                 ),
                                 priority: None,
                             ),
-                        ],
-                        note: None,
-                    ),
-                    priority: None,
-                ),
-            ],
-        ),
-        (
-            name: "[Aperture-Lab] Print Invitation on Asbestos",
-            note: None,
-            only_once: true,
-            event: useItem(
-                item: "lab_printer",
-                ability: turnOn,
-            ),
-            conditions: Pred(containerHasItem(
-                container: "lab_printer",
-                item: "asbestos_sheet",
-            )),
-            actions: [
-                (
-                    action: addFlag(
-                        flag: simple(
-                            name: "invitation-sans-ignition",
-                        ),
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: awardPoints(
-                        amount: 10,
-                        reason: "Printed the invitation on asbestos stock",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: despawnItem(
-                        item: "asbestos_sheet",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: showMessage(
-                        text: "The PlasmaJet emits a blinding flash of light, leaving a printer-shaped purple blob in your visual field and blinding you for a few moments.",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: scheduleIn(
-                        turns_ahead: 2,
-                        actions: [
+                            (
+                                action: addFlag(
+                                    flag: simple(
+                                        name: "burned-invitation",
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: despawnItem(
+                                    item: "printer_paper",
+                                ),
+                                priority: None,
+                            ),
                             (
                                 action: spawnItemInRoom(
-                                    item: "invitation",
+                                    item: "flaming_invitation",
                                     room: "aperture-lab",
                                 ),
                                 priority: None,
                             ),
                             (
-                                action: showMessage(
-                                    text: "Your vision begins to clear, and you see an engraved invitation on the floor. It glows slightly, and waves of heat warp the air around it.",
+                                action: scheduleIn(
+                                    turns_ahead: 5,
+                                    actions: [
+                                        (
+                                            action: showMessage(
+                                                text: "The flaming invitation goes fizzles out, leaving behind a few charred remains.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: replaceItem(
+                                                old_item: "flaming_invitation",
+                                                new_item: "charred_invitation_bits",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    note: Some("invitation finishes burning"),
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: addSpinnerWedge(
+                                    spinner: "ambientInterior",
+                                    text: "An annoyed voice on the PA: ATTENTION Staff - do NOT use regular copy paper in the lab PlasmaJet printer, or we will be shut down again -- by order of FEMA, PETA, the ATF, FBI, and our HOA.",
+                                    width: 1,
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: scheduleIn(
+                                    turns_ahead: 2,
+                                    actions: [
+                                        (
+                                            action: showMessage(
+                                                text: "A nearby smoke detector alarms briefly, the quits with an exasperated sigh when it sees you near the PlasmaJet printer, figuring you get what you deserve.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    note: Some("desensitized smoke detector"),
                                 ),
                                 priority: None,
                             ),
                         ],
-                        note: Some("blindness clears"),
+                        false_actions: Some([
+                            (
+                                action: conditional(
+                                    condition: Pred(containerHasItem(
+                                        container: "lab_printer",
+                                        item: "asbestos_sheet",
+                                    )),
+                                    actions: [
+                                        (
+                                            action: addFlag(
+                                                flag: simple(
+                                                    name: "invitation-sans-ignition",
+                                                ),
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: awardPoints(
+                                                amount: 10,
+                                                reason: "Printed the invitation on asbestos stock",
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: despawnItem(
+                                                item: "asbestos_sheet",
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: spawnItemInRoom(
+                                                item: "invitation",
+                                                room: "aperture-lab",
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: addFlag(
+                                                flag: simple(
+                                                    name: "status:flash-blind",
+                                                ),
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: showMessage(
+                                                text: "The PlasmaJet emits a blinding flash of light, leaving a printer-shaped purple blob in your visual field and blinding you for a few moments.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: modifyRoom(
+                                                room: "aperture-lab",
+                                                patch: (
+                                                    name: Some("Purple Blob Lab"),
+                                                    desc: Some("It still feels like you\'re in the lab, but all you can see is a fading purple blob in your central vision."),
+                                                    remove_exits: [
+                                                        "portal-room",
+                                                        "stargate-room",
+                                                    ],
+                                                    add_exits: [],
+                                                ),
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: scheduleIn(
+                                                turns_ahead: 3,
+                                                actions: [
+                                                    (
+                                                        action: showMessage(
+                                                            text: "Your vision begins to clear, and you see an invitation on the floor, burned into the asbestos sheet. It glows slightly, and waves of heat warp the air around it.",
+                                                        ),
+                                                        priority: None,
+                                                    ),
+                                                    (
+                                                        action: removeFlag(
+                                                            name: "status:flash-blind",
+                                                        ),
+                                                        priority: None,
+                                                    ),
+                                                    (
+                                                        action: modifyRoom(
+                                                            room: "aperture-lab",
+                                                            patch: (
+                                                                name: Some("Aperture Laboratory"),
+                                                                desc: Some("The walls, floor, ceiling, and even the air here feels clinical and overexposed. Everything hums at a frequency designed to encourage strict compliance. A few [[bright-red]]fire extinguishers[[/bright-red]] are scattered about. A very dated computer console glows green on a table beside a [[i]]highly[[/i]] over-engineered printer labeled [[hl]][[b]]Aperture|Amble Hospitality Generator[[/b]][[/hl]]. Across the room, a [[item]]vault-like door[[/item]] all but [[i]]demands[[/i]] attention."),
+                                                                remove_exits: [],
+                                                                add_exits: [
+                                                                    (
+                                                                        direction: "through the portal",
+                                                                        to: "portal-room",
+                                                                        hidden: false,
+                                                                        locked: false,
+                                                                        required_flags: [],
+                                                                        required_items: [],
+                                                                        barred_message: None,
+                                                                    ),
+                                                                    (
+                                                                        direction: "into the vault",
+                                                                        to: "stargate-room",
+                                                                        hidden: false,
+                                                                        locked: false,
+                                                                        required_flags: [],
+                                                                        required_items: [],
+                                                                        barred_message: None,
+                                                                    ),
+                                                                ],
+                                                            ),
+                                                        ),
+                                                        priority: None,
+                                                    ),
+                                                ],
+                                                note: Some("flash blindness clears"),
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    false_actions: Some([
+                                        (
+                                            action: showMessage(
+                                                text: "The printer just clicks once. You may want to check the status screen or the paper tray.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ]),
+                                ),
+                                priority: None,
+                            ),
+                        ]),
                     ),
                     priority: None,
                 ),
@@ -7957,6 +8404,12 @@
             conditions: All([]),
             actions: [
                 (
+                    action: showMessage(
+                        text: "Elated that you\'ve given it such a large, empty battery to charge, the gonk droid gives you a fully charged one, free of ... charge?",
+                    ),
+                    priority: None,
+                ),
+                (
                     action: awardPoints(
                         amount: 2,
                         reason: "Swapped the drained battery with the helpful gonk droid",
@@ -7980,15 +8433,17 @@
                     priority: None,
                 ),
                 (
-                    action: setNpcState(
-                        npc: "gonk_droid",
-                        state: happy,
+                    action: addFlag(
+                        flag: simple(
+                            name: "got-charged-battery",
+                        ),
                     ),
                     priority: None,
                 ),
                 (
-                    action: showMessage(
-                        text: "Elated that you\'ve given it such a large, empty battery to charge, the gonk droid gives you a fully charged one, free of ... charge?",
+                    action: setNpcState(
+                        npc: "gonk_droid",
+                        state: happy,
                     ),
                     priority: None,
                 ),
@@ -8024,6 +8479,12 @@
             conditions: All([]),
             actions: [
                 (
+                    action: showMessage(
+                        text: "Arcing wildly as you insert it, the fully charged 20 KV battery fuses itself to the contacts inside the portal gun -- when then emits a quick high-pitched whine. The POWER indicator lights a steady green.",
+                    ),
+                    priority: None,
+                ),
+                (
                     action: addFlag(
                         flag: simple(
                             name: "portal-gun-powered",
@@ -8054,72 +8515,145 @@
                     ),
                     priority: None,
                 ),
-                (
-                    action: showMessage(
-                        text: "Arcing wildly as you insert it, the fully charged 20 KV battery fuses itself to the contacts inside the portal gun -- when then emits a quick high-pitched whine. The POWER indicator lights a steady green.",
-                    ),
-                    priority: None,
-                ),
             ],
         ),
         (
             name: "[Portal-Room] Gun Fired / Open Portal",
-            note: None,
-            only_once: true,
-            event: useItem(
-                item: "portal_gun",
-                ability: turnOn,
-            ),
-            conditions: Pred(hasFlag(
-                flag: "portal-gun-powered",
-            )),
-            actions: [
-                (
-                    action: revealExit(
-                        exit_from: "portal-room",
-                        exit_to: "aperture-lab",
-                        direction: "through the portal",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: addFlag(
-                        flag: simple(
-                            name: "portal-opened",
-                        ),
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: awardPoints(
-                        amount: 5,
-                        reason: "Opened a portal into Aperture Labs",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: showMessage(
-                        text: "A loud SQUIP! comes from the gun when you turn it on. The wall in front of it sizzles for a moment, and then a crackling oval blue portal expands there to reveal a laboratory space on the other side.",
-                    ),
-                    priority: None,
-                ),
-            ],
-        ),
-        (
-            name: "[Portal-Room] Tried Gun Without Power",
             note: None,
             only_once: false,
             event: useItem(
                 item: "portal_gun",
                 ability: turnOn,
             ),
-            conditions: Pred(missingFlag(
-                flag: "portal-gun-powered",
-            )),
+            conditions: All([]),
+            actions: [
+                (
+                    action: conditional(
+                        condition: Pred(hasFlag(
+                            flag: "portal-opened",
+                        )),
+                        actions: [
+                            (
+                                action: showMessage(
+                                    text: "The gun emits a low [[hl]]brop[[/hl] sound and the portal changes shape, but the view to the laboratory on the other side remains the same.",
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        false_actions: Some([
+                            (
+                                action: conditional(
+                                    condition: Pred(hasFlag(
+                                        flag: "portal-gun-powered",
+                                    )),
+                                    actions: [
+                                        (
+                                            action: showMessage(
+                                                text: "A loud SQUIP! comes from the gun when you turn it on. The wall in front of it sizzles for a moment, and then a crackling oval blue portal expands there to reveal a laboratory space on the other side.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: revealExit(
+                                                exit_from: "portal-room",
+                                                exit_to: "aperture-lab",
+                                                direction: "through the portal",
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: addFlag(
+                                                flag: simple(
+                                                    name: "portal-opened",
+                                                ),
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: awardPoints(
+                                                amount: 5,
+                                                reason: "Opened a portal into Aperture Labs",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    false_actions: Some([
+                                        (
+                                            action: showMessage(
+                                                text: "You attempt to turn the portal gun on, but the POWER light briefly flashes red, then goes dark. Nothing else happens.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ]),
+                                ),
+                                priority: None,
+                            ),
+                        ]),
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[Antechamber] First Arrival",
+            note: None,
+            only_once: true,
+            event: enterRoom(
+                room: "antechamber",
+            ),
+            conditions: All([]),
             actions: [
                 (
                     action: showMessage(
-                        text: "You attempt to turn the portal gun on, but the POWER light briefly flashes red, then goes dark. Nothing else happens.",
+                        text: "The room greets you with the hushed tension of a place in which people have spent centuries being polite at each other as hard as they can.",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: scheduleInIf(
+                        turns_ahead: 2,
+                        condition: Pred(playerInRoom(
+                            room: "antechamber",
+                        )),
+                        on_false: cancel,
+                        actions: [
+                            (
+                                action: conditional(
+                                    condition: Pred(hasFlag(
+                                        flag: "sect-shoe",
+                                    )),
+                                    actions: [
+                                        (
+                                            action: showMessage(
+                                                text: "From somewhere beyond the gourd-marked door comes a muffled chant whose general theme appears to be that vegetables were a mistake.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    false_actions: Some([
+                                        (
+                                            action: conditional(
+                                                condition: Pred(hasFlag(
+                                                    flag: "sect-gourd",
+                                                )),
+                                                actions: [
+                                                    (
+                                                        action: showMessage(
+                                                            text: "From somewhere beyond the sandal-marked door comes a clipped chorus suggesting that produce has no business in serious metaphysics.",
+                                                        ),
+                                                        priority: None,
+                                                    ),
+                                                ],
+                                                false_actions: None,
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ]),
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        note: None,
                     ),
                     priority: None,
                 ),
@@ -8215,6 +8749,76 @@
                     action: setItemDescription(
                         item: "lost_and_found_box",
                         text: "A sturdy metal lockbox marked \'Lost and Found\'. Its lid is cracked slightly open.",
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[Gourd-Shrine] First Visit",
+            note: None,
+            only_once: true,
+            event: enterRoom(
+                room: "gourd-shrine",
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: showMessage(
+                        text: "A tranquil hush settles around you. It is the sort of hush that fully expects applause for being tranquil.",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: scheduleInIf(
+                        turns_ahead: 2,
+                        condition: Pred(playerInRoom(
+                            room: "gourd-shrine",
+                        )),
+                        on_false: cancel,
+                        actions: [
+                            (
+                                action: showMessage(
+                                    text: "A hidden choir hums a note so warm and rounded it feels less heard than gently ladled.",
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        note: None,
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[Gourd-Shrine] Touch Altar",
+            note: None,
+            only_once: false,
+            event: touchItem(
+                item: "harvest_altar",
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: showMessage(
+                        text: "The polished surface is warm to the touch. Either candles burn nearby, or devotion here has been left simmering.",
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[Gourd-Shrine] Touch Abacus",
+            note: None,
+            only_once: false,
+            event: touchItem(
+                item: "seed_abacus",
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: showMessage(
+                        text: "Several seeds click across the rods and settle on a number that feels meaningful, though it may simply indicate soup.",
                     ),
                     priority: None,
                 ),
@@ -8444,7 +9048,7 @@
             actions: [
                 (
                     action: scheduleIn(
-                        turns_ahead: 7,
+                        turns_ahead: 10,
                         actions: [
                             (
                                 action: replaceItem(
@@ -8935,121 +9539,6 @@
                 item: "plaque_3",
                 ability: read,
             ),
-            conditions: Pred(hasVisited(
-                room: "stargate-room",
-            )),
-            actions: [
-                (
-                    action: showMessage(
-                        text: "(A new Stargate destination has been enabled.)",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: modifyRoom(
-                        room: "stargate-room",
-                        patch: (
-                            name: None,
-                            desc: Some("A hangar-size concrete room, connected to the Aperture lab through a round vault door. The Stargate in the center is filled with a shimmering energy, from which you hear the sounds of clinking glasses punctuated by explosions. Occasionally, you catch a whiff of fresh baked bread in the air."),
-                            remove_exits: [
-                                "ice-pit",
-                                "parish-landing",
-                            ],
-                            add_exits: [
-                                (
-                                    direction: "through the stargate",
-                                    to: "patio",
-                                    hidden: false,
-                                    locked: false,
-                                    required_flags: [],
-                                    required_items: [],
-                                    barred_message: None,
-                                ),
-                            ],
-                        ),
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: addFlag(
-                        flag: simple(
-                            name: "patio-gate-open",
-                        ),
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: modifyRoom(
-                        room: "patio",
-                        patch: (
-                            name: None,
-                            desc: None,
-                            remove_exits: [],
-                            add_exits: [
-                                (
-                                    direction: "through the stargate",
-                                    to: "stargate-room",
-                                    hidden: false,
-                                    locked: false,
-                                    required_flags: [],
-                                    required_items: [],
-                                    barred_message: None,
-                                ),
-                            ],
-                        ),
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: removeFlag(
-                        name: "woodland-gate-open",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: modifyRoom(
-                        room: "parish-landing",
-                        patch: (
-                            name: None,
-                            desc: None,
-                            remove_exits: [
-                                "stargate-room",
-                            ],
-                            add_exits: [],
-                        ),
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: removeFlag(
-                        name: "snowfield-gate-open",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: modifyRoom(
-                        room: "ice-pit",
-                        patch: (
-                            name: None,
-                            desc: None,
-                            remove_exits: [
-                                "stargate-room",
-                            ],
-                            add_exits: [],
-                        ),
-                    ),
-                    priority: None,
-                ),
-            ],
-        ),
-        (
-            name: "[Plaque 3] Read the Plaque",
-            note: None,
-            only_once: true,
-            event: useItem(
-                item: "plaque_3",
-                ability: read,
-            ),
             conditions: All([]),
             actions: [
                 (
@@ -9064,6 +9553,146 @@
                     action: awardPoints(
                         amount: 10,
                         reason: "Reached and read the third crystal plaque",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: conditional(
+                        condition: Pred(hasVisited(
+                            room: "stargate-room",
+                        )),
+                        actions: [
+                            (
+                                action: showMessage(
+                                    text: "(A new Stargate destination has been enabled.)",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: modifyRoom(
+                                    room: "stargate-room",
+                                    patch: (
+                                        name: None,
+                                        desc: Some("A hangar-size concrete room, connected to the Aperture lab through a round vault door. The Stargate in the center is filled with a shimmering energy, from which you hear the sounds of clinking glasses punctuated by explosions. Occasionally, you catch a whiff of fresh baked bread in the air."),
+                                        remove_exits: [
+                                            "ice-pit",
+                                            "parish-landing",
+                                            "antechamber",
+                                        ],
+                                        add_exits: [
+                                            (
+                                                direction: "through the stargate",
+                                                to: "patio",
+                                                hidden: false,
+                                                locked: false,
+                                                required_flags: [],
+                                                required_items: [],
+                                                barred_message: None,
+                                            ),
+                                        ],
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: addFlag(
+                                    flag: simple(
+                                        name: "patio-gate-open",
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: modifyRoom(
+                                    room: "patio",
+                                    patch: (
+                                        name: None,
+                                        desc: None,
+                                        remove_exits: [],
+                                        add_exits: [
+                                            (
+                                                direction: "through the stargate",
+                                                to: "stargate-room",
+                                                hidden: false,
+                                                locked: false,
+                                                required_flags: [],
+                                                required_items: [],
+                                                barred_message: None,
+                                            ),
+                                        ],
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: removeFlag(
+                                    name: "woodland-gate-open",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: modifyRoom(
+                                    room: "parish-landing",
+                                    patch: (
+                                        name: None,
+                                        desc: None,
+                                        remove_exits: [
+                                            "stargate-room",
+                                        ],
+                                        add_exits: [],
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: removeFlag(
+                                    name: "snowfield-gate-open",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: modifyRoom(
+                                    room: "ice-pit",
+                                    patch: (
+                                        name: None,
+                                        desc: None,
+                                        remove_exits: [
+                                            "stargate-room",
+                                        ],
+                                        add_exits: [],
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: removeFlag(
+                                    name: "sect-gate-open",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: modifyRoom(
+                                    room: "antechamber",
+                                    patch: (
+                                        name: None,
+                                        desc: None,
+                                        remove_exits: [
+                                            "stargate-room",
+                                        ],
+                                        add_exits: [],
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        false_actions: Some([
+                            (
+                                action: showMessage(
+                                    text: "(Somewhere, something connected has been enabled.)",
+                                ),
+                                priority: None,
+                            ),
+                        ]),
                     ),
                     priority: None,
                 ),
@@ -9313,68 +9942,312 @@
             ],
         ),
         (
-            name: "HINT Radio: Where do I charge this battery?",
+            name: "[Shoe-Shrine] First Visit",
             note: None,
             only_once: true,
-            event: takeItem(
-                item: "empty_battery",
+            event: enterRoom(
+                room: "shoe-shrine",
             ),
             conditions: All([]),
             actions: [
                 (
+                    action: showMessage(
+                        text: "A discreet bell chimes somewhere overhead, as if noting your arrival in a ledger maintained by very tidy angels.",
+                    ),
+                    priority: None,
+                ),
+                (
                     action: scheduleInIf(
                         turns_ahead: 2,
-                        condition: Any([
-                            All([
-                                Pred(hasItem(
-                                    item: "hint_radio",
-                                )),
-                                Pred(hasFlag(
-                                    flag: "hint-radio-on",
-                                )),
-                                Pred(missingFlag(
-                                    flag: "portal-gun-powered",
-                                )),
-                                Pred(playerInRoom(
-                                    room: "portal-room",
-                                )),
-                            ]),
-                            Pred(hasFlag(
-                                flag: "portal-gun-powered",
-                            )),
-                        ]),
-                        on_false: retryNextTurn,
+                        condition: Pred(playerInRoom(
+                            room: "shoe-shrine",
+                        )),
+                        on_false: cancel,
                         actions: [
                             (
-                                action: conditional(
-                                    condition: All([
-                                        Pred(hasItem(
-                                            item: "hint_radio",
-                                        )),
-                                        Pred(hasFlag(
-                                            flag: "hint-radio-on",
-                                        )),
-                                        Pred(missingFlag(
-                                            flag: "portal-gun-powered",
-                                        )),
-                                        Pred(playerInRoom(
-                                            room: "portal-room",
-                                        )),
-                                    ]),
-                                    actions: [
-                                        (
-                                            action: npcSays(
-                                                npc: "hint_radio_npc",
-                                                quote: "Wasn\'t there a gonk droid clomping about up in the lounge or the lobby? They can power or charge just about anything, from what I hear. Not much for conversation though, the gonks.",
-                                            ),
-                                            priority: None,
-                                        ),
-                                    ],
+                                action: showMessage(
+                                    text: "From the rafters comes a whisper: \"If the Shoe fits...\" followed by several devout voices murmuring, \"...mind the laces of destiny.\"",
                                 ),
                                 priority: None,
                             ),
                         ],
                         note: None,
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[Shoe-Shrine] Touch Altar",
+            note: None,
+            only_once: false,
+            event: touchItem(
+                item: "sandal_altar",
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: showMessage(
+                        text: "The wood is mirror-smooth and faintly warm. The shrine\'s caretakers either polish constantly or have achieved a workable theology of wax.",
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[Shoe-Shrine] Touch Donation Box",
+            note: None,
+            only_once: false,
+            event: touchItem(
+                item: "heel_the_poor_fund",
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: showMessage(
+                        text: "The box gives off the dense metallic clink of accumulated virtue.",
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[Stargate] Sect Gate: Activate",
+            note: Some("schedule/give point award for first time opening gate"),
+            only_once: true,
+            event: touchItem(
+                item: "sect_gate_button",
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: scheduleInIf(
+                        turns_ahead: 1,
+                        condition: Any([
+                            Pred(hasFlag(
+                                flag: "sect-shoe",
+                            )),
+                            Pred(hasFlag(
+                                flag: "sect-gourd",
+                            )),
+                        ]),
+                        on_false: retryNextTurn,
+                        actions: [
+                            (
+                                action: awardPoints(
+                                    amount: 5,
+                                    reason: "Activated the Sectarian Gate",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: addFlag(
+                                    flag: simple(
+                                        name: "sect-gate-enabled",
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        note: None,
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[Stargate] Press Woodland Button",
+            note: Some("open/move the Stargate connection to the Sect Antechamber (only if a member)"),
+            only_once: false,
+            event: touchItem(
+                item: "sect_gate_button",
+            ),
+            conditions: All([
+                Any([
+                    Pred(hasFlag(
+                        flag: "sect-shoe",
+                    )),
+                    Pred(hasFlag(
+                        flag: "sect-gourd",
+                    )),
+                ]),
+                Pred(missingFlag(
+                    flag: "sect-gate-open",
+                )),
+            ]),
+            actions: [
+                (
+                    action: showMessage(
+                        text: "With a great whooshing like the flush of a titan\'s toilet, the Stargate opens a new connection. Angelic sounds float through the gate, oddly paired with the smell of leather and pumpkins.",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: modifyRoom(
+                        room: "stargate-room",
+                        patch: (
+                            name: None,
+                            desc: Some("A hangar-size concrete room, connected to the Aperture lab through a huge, round vault door. The Stargate is filled with a shimmering energy, from which you hear faint choir-like — [[i]]almost angelic[[/i]] — sound. Occasionally, you catch a whiff of leather. Or pumpkin?"),
+                            remove_exits: [
+                                "ice-pit",
+                                "patio",
+                                "parish-landing",
+                            ],
+                            add_exits: [
+                                (
+                                    direction: "through the stargate",
+                                    to: "antechamber",
+                                    hidden: false,
+                                    locked: false,
+                                    required_flags: [],
+                                    required_items: [],
+                                    barred_message: None,
+                                ),
+                            ],
+                        ),
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: addFlag(
+                        flag: simple(
+                            name: "sect-gate-open",
+                        ),
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: modifyRoom(
+                        room: "antechamber",
+                        patch: (
+                            name: None,
+                            desc: None,
+                            remove_exits: [],
+                            add_exits: [
+                                (
+                                    direction: "through the stargate",
+                                    to: "stargate-room",
+                                    hidden: false,
+                                    locked: false,
+                                    required_flags: [],
+                                    required_items: [],
+                                    barred_message: None,
+                                ),
+                            ],
+                        ),
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: removeFlag(
+                        name: "snowfield-gate-open",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: modifyRoom(
+                        room: "ice-pit",
+                        patch: (
+                            name: None,
+                            desc: None,
+                            remove_exits: [
+                                "stargate-room",
+                            ],
+                            add_exits: [],
+                        ),
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: removeFlag(
+                        name: "patio-gate-open",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: modifyRoom(
+                        room: "patio",
+                        patch: (
+                            name: None,
+                            desc: None,
+                            remove_exits: [
+                                "stargate-room",
+                            ],
+                            add_exits: [],
+                        ),
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: removeFlag(
+                        name: "woodland-gate-open",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: modifyRoom(
+                        room: "parish-landing",
+                        patch: (
+                            name: None,
+                            desc: None,
+                            remove_exits: [
+                                "stargate-room",
+                            ],
+                            add_exits: [],
+                        ),
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[Stargate] Press Woodland Button",
+            note: Some("open/move the Stargate connection to the Sect Antechamber (only if a member)"),
+            only_once: false,
+            event: touchItem(
+                item: "sect_gate_button",
+            ),
+            conditions: All([
+                Any([
+                    Pred(hasFlag(
+                        flag: "sect-shoe",
+                    )),
+                    Pred(hasFlag(
+                        flag: "sect-gourd",
+                    )),
+                ]),
+                Pred(hasFlag(
+                    flag: "sect-gate-open",
+                )),
+            ]),
+            actions: [
+                (
+                    action: showMessage(
+                        text: "The gate to the antechamber is already open.",
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[Stargate] Press Woodland Button",
+            note: Some("open/move the Stargate connection to the Sect Antechamber (only if a member)"),
+            only_once: false,
+            event: touchItem(
+                item: "sect_gate_button",
+            ),
+            conditions: All([
+                Pred(missingFlag(
+                    flag: "sect-shoe",
+                )),
+                Pred(missingFlag(
+                    flag: "sect-gourd",
+                )),
+            ]),
+            actions: [
+                (
+                    action: showMessage(
+                        text: "The fish button is already pressed down as far as it can go; you can\'t activate it.",
                     ),
                     priority: None,
                 ),
@@ -9450,6 +10323,7 @@
                             remove_exits: [
                                 "ice-pit",
                                 "patio",
+                                "antechamber",
                             ],
                             add_exits: [
                                 (
@@ -9525,6 +10399,26 @@
                 (
                     action: modifyRoom(
                         room: "patio",
+                        patch: (
+                            name: None,
+                            desc: None,
+                            remove_exits: [
+                                "stargate-room",
+                            ],
+                            add_exits: [],
+                        ),
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: removeFlag(
+                        name: "sect-gate-open",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: modifyRoom(
+                        room: "antechamber",
                         patch: (
                             name: None,
                             desc: None,
@@ -9651,6 +10545,7 @@
                             remove_exits: [
                                 "parish-landing",
                                 "patio",
+                                "antechamber",
                             ],
                             add_exits: [
                                 (
@@ -9726,6 +10621,26 @@
                 (
                     action: modifyRoom(
                         room: "patio",
+                        patch: (
+                            name: None,
+                            desc: None,
+                            remove_exits: [
+                                "stargate-room",
+                            ],
+                            add_exits: [],
+                        ),
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: removeFlag(
+                        name: "sect-gate-open",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: modifyRoom(
+                        room: "antechamber",
                         patch: (
                             name: None,
                             desc: None,
@@ -9852,6 +10767,7 @@
                             remove_exits: [
                                 "ice-pit",
                                 "parish-landing",
+                                "antechamber",
                             ],
                             add_exits: [
                                 (
@@ -9927,6 +10843,26 @@
                 (
                     action: modifyRoom(
                         room: "ice-pit",
+                        patch: (
+                            name: None,
+                            desc: None,
+                            remove_exits: [
+                                "stargate-room",
+                            ],
+                            add_exits: [],
+                        ),
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: removeFlag(
+                        name: "sect-gate-open",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: modifyRoom(
+                        room: "antechamber",
                         patch: (
                             name: None,
                             desc: None,
@@ -11165,6 +12101,7 @@
                             remove_exits: [
                                 "parish-landing",
                                 "patio",
+                                "antechamber",
                             ],
                             add_exits: [
                                 (
@@ -11240,6 +12177,26 @@
                 (
                     action: modifyRoom(
                         room: "patio",
+                        patch: (
+                            name: None,
+                            desc: None,
+                            remove_exits: [
+                                "stargate-room",
+                            ],
+                            add_exits: [],
+                        ),
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: removeFlag(
+                        name: "sect-gate-open",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: modifyRoom(
+                        room: "antechamber",
                         patch: (
                             name: None,
                             desc: None,
@@ -11516,176 +12473,12 @@
                                             priority: None,
                                         ),
                                     ],
+                                    false_actions: None,
                                 ),
                                 priority: None,
                             ),
                         ],
                         note: Some("finish burning campfire down"),
-                    ),
-                    priority: None,
-                ),
-            ],
-        ),
-        (
-            name: "Hint: Find Items to Build a Fire",
-            note: Some("schedule radio hint about building a fire"),
-            only_once: true,
-            event: useItem(
-                item: "plaque_2_frozen",
-                ability: read,
-            ),
-            conditions: All([]),
-            actions: [
-                (
-                    action: scheduleInIf(
-                        turns_ahead: 4,
-                        condition: Any([
-                            All([
-                                Pred(missingFlag(
-                                    flag: "campfire-lit",
-                                )),
-                                All([
-                                    Pred(hasItem(
-                                        item: "hint_radio",
-                                    )),
-                                    Pred(hasFlag(
-                                        flag: "hint-radio-on",
-                                    )),
-                                ]),
-                                Pred(playerInRoom(
-                                    room: "ice-pit",
-                                )),
-                            ]),
-                            Pred(hasFlag(
-                                flag: "campfire-lit",
-                            )),
-                        ]),
-                        on_false: retryNextTurn,
-                        actions: [
-                            (
-                                action: conditional(
-                                    condition: All([
-                                        Pred(missingFlag(
-                                            flag: "campfire-lit",
-                                        )),
-                                        All([
-                                            Pred(hasItem(
-                                                item: "hint_radio",
-                                            )),
-                                            Pred(hasFlag(
-                                                flag: "hint-radio-on",
-                                            )),
-                                        ]),
-                                        Pred(playerInRoom(
-                                            room: "ice-pit",
-                                        )),
-                                    ]),
-                                    actions: [
-                                        (
-                                            action: npcSays(
-                                                npc: "hint_radio_npc",
-                                                quote: "To melt that pillar, you\'ll need to drop some firewood here and light it with something.",
-                                            ),
-                                            priority: None,
-                                        ),
-                                    ],
-                                ),
-                                priority: None,
-                            ),
-                        ],
-                        note: Some("radio gives campfire hint"),
-                    ),
-                    priority: None,
-                ),
-            ],
-        ),
-        (
-            name: "Firewood HINT",
-            note: Some("HINT radio: add firewood hint to scheduler"),
-            only_once: true,
-            event: enterRoom(
-                room: "snow-camp",
-            ),
-            conditions: All([]),
-            actions: [
-                (
-                    action: scheduleInIf(
-                        turns_ahead: 4,
-                        condition: Any([
-                            All([
-                                All([
-                                    Pred(hasItem(
-                                        item: "hint_radio",
-                                    )),
-                                    Pred(hasFlag(
-                                        flag: "hint-radio-on",
-                                    )),
-                                ]),
-                                Pred(hasFlag(
-                                    flag: "tried-read-plaque-2",
-                                )),
-                                Pred(missingFlag(
-                                    flag: "campfire-lit",
-                                )),
-                                Pred(missingItem(
-                                    item: "firewood",
-                                )),
-                                Pred(playerInRoom(
-                                    room: "snow-camp",
-                                )),
-                            ]),
-                            Any([
-                                Pred(hasFlag(
-                                    flag: "read-plaque-2",
-                                )),
-                                Pred(hasFlag(
-                                    flag: "campfire-lit",
-                                )),
-                                Pred(hasItem(
-                                    item: "firewood",
-                                )),
-                            ]),
-                        ]),
-                        on_false: retryNextTurn,
-                        actions: [
-                            (
-                                action: conditional(
-                                    condition: All([
-                                        All([
-                                            Pred(hasItem(
-                                                item: "hint_radio",
-                                            )),
-                                            Pred(hasFlag(
-                                                flag: "hint-radio-on",
-                                            )),
-                                        ]),
-                                        Pred(hasFlag(
-                                            flag: "tried-read-plaque-2",
-                                        )),
-                                        Pred(missingFlag(
-                                            flag: "campfire-lit",
-                                        )),
-                                        Pred(missingItem(
-                                            item: "firewood",
-                                        )),
-                                        Pred(playerInRoom(
-                                            room: "snow-camp",
-                                        )),
-                                    ]),
-                                    actions: [
-                                        (
-                                            action: npcSays(
-                                                npc: "hint_radio_npc",
-                                                quote: "Looks like the researchers didn\'t get their fire lit before the dog-Thing got to them. Bad day for them, but maybe good for you. Could you move the firewood down into the ice pit to melt the ice around the frozen pillar?",
-                                            ),
-                                            priority: None,
-                                        ),
-                                    ],
-                                ),
-                                priority: None,
-                            ),
-                        ],
-                        note: Some("HINT radio: deliver firewood hint"),
                     ),
                     priority: None,
                 ),
@@ -11814,6 +12607,7 @@
                                             priority: Some(-50),
                                         ),
                                     ],
+                                    false_actions: None,
                                 ),
                                 priority: None,
                             ),
@@ -11830,6 +12624,7 @@
                                             priority: Some(-50),
                                         ),
                                     ],
+                                    false_actions: None,
                                 ),
                                 priority: None,
                             ),
@@ -12309,6 +13104,7 @@
                             remove_exits: [
                                 "ice-pit",
                                 "patio",
+                                "antechamber",
                             ],
                             add_exits: [
                                 (
@@ -12384,6 +13180,26 @@
                 (
                     action: modifyRoom(
                         room: "patio",
+                        patch: (
+                            name: None,
+                            desc: None,
+                            remove_exits: [
+                                "stargate-room",
+                            ],
+                            add_exits: [],
+                        ),
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: removeFlag(
+                        name: "sect-gate-open",
+                    ),
+                    priority: None,
+                ),
+                (
+                    action: modifyRoom(
+                        room: "antechamber",
                         patch: (
                             name: None,
                             desc: None,
@@ -12482,37 +13298,63 @@
             conditions: All([]),
             actions: [
                 (
-                    action: showMessage(
-                        text: "Modifying the Luggage...",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: modifyNpc(
-                        npc: "the_luggage",
-                        patch: (
-                            name: Some("Hungry Luggage"),
-                            desc: Some("The Luggage is ravenous! Beware!!"),
-                            state: Some(custom("hungry")),
-                            add_lines: [
-                                (
-                                    state: custom("hungry"),
-                                    line: "(The Luggage nearly bites your face off when you approach.)",
+                    action: conditional(
+                        condition: Pred(missingFlag(
+                            flag: "tried-the-blue-button",
+                        )),
+                        actions: [
+                            (
+                                action: addFlag(
+                                    flag: simple(
+                                        name: "tried-the-blue-button",
+                                    ),
                                 ),
-                            ],
-                            movement: Some((
-                                route: None,
-                                random_rooms: Some([
-                                    "dev-room",
-                                    "lounge",
-                                ]),
-                                timing: Some(everyNTurns(
-                                    turns: 5,
-                                )),
-                                active: Some(true),
-                                loop_route: Some(true),
-                            )),
-                        ),
+                                priority: None,
+                            ),
+                            (
+                                action: showMessage(
+                                    text: "That will make the Luggage hungry. You might want to rethink that.",
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        false_actions: Some([
+                            (
+                                action: showMessage(
+                                    text: "Modifying the Luggage...",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: modifyNpc(
+                                    npc: "the_luggage",
+                                    patch: (
+                                        name: Some("Hungry Luggage"),
+                                        desc: Some("The Luggage is ravenous! Beware!!"),
+                                        state: Some(custom("hungry")),
+                                        add_lines: [
+                                            (
+                                                state: custom("hungry"),
+                                                line: "(The Luggage nearly bites your face off when you approach.)",
+                                            ),
+                                        ],
+                                        movement: Some((
+                                            route: None,
+                                            random_rooms: Some([
+                                                "dev-room",
+                                                "lounge",
+                                            ]),
+                                            timing: Some(everyNTurns(
+                                                turns: 5,
+                                            )),
+                                            active: Some(true),
+                                            loop_route: Some(true),
+                                        )),
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                        ]),
                     ),
                     priority: None,
                 ),
@@ -12797,32 +13639,29 @@
             event: dropItem(
                 item: "vogon_poetry_book",
             ),
-            conditions: Pred(missingFlag(
-                flag: "read-vogon-poetry",
-            )),
+            conditions: All([]),
             actions: [
                 (
-                    action: showMessage(
-                        text: "That greasy, queasy feeling subsides.",
-                    ),
-                    priority: None,
-                ),
-            ],
-        ),
-        (
-            name: "[Global] Drop Vogon Poetry",
-            note: Some("dropping only stops the nausea if player has not read it"),
-            only_once: false,
-            event: dropItem(
-                item: "vogon_poetry_book",
-            ),
-            conditions: Pred(hasFlag(
-                flag: "read-vogon-poetry",
-            )),
-            actions: [
-                (
-                    action: showMessage(
-                        text: "Getting rid of the book helps a little, but the poem is burned into your mind and the nausea continues.",
+                    action: conditional(
+                        condition: Pred(hasFlag(
+                            flag: "read-vogon-poetry",
+                        )),
+                        actions: [
+                            (
+                                action: showMessage(
+                                    text: "Getting rid of the book helps a little, but the poem is burned into your mind and the nausea continues.",
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        false_actions: Some([
+                            (
+                                action: showMessage(
+                                    text: "That greasy, queasy feeling quickly subsides.",
+                                ),
+                                priority: None,
+                            ),
+                        ]),
                     ),
                     priority: None,
                 ),
@@ -13233,74 +14072,6 @@
                             name: "module-2-puzzle",
                             end: Some(2),
                         ),
-                    ),
-                    priority: None,
-                ),
-            ],
-        ),
-        (
-            name: "[HINT Available] Make A Fishing Line",
-            note: Some("makes hint available when HAL module trapped in crevice"),
-            only_once: true,
-            event: useItemOnItem(
-                tool: "crowbar",
-                target: "vending_machine",
-                interaction: open,
-            ),
-            conditions: All([]),
-            actions: [
-                (
-                    action: scheduleInIf(
-                        turns_ahead: 2,
-                        condition: Any([
-                            All([
-                                All([
-                                    Pred(hasItem(
-                                        item: "hint_radio",
-                                    )),
-                                    Pred(hasFlag(
-                                        flag: "hint-radio-on",
-                                    )),
-                                ]),
-                                Pred(hasFlag(
-                                    flag: "hal-module-in-crevice",
-                                )),
-                            ]),
-                            Pred(hasFlag(
-                                flag: "module-2-retrieved",
-                            )),
-                        ]),
-                        on_false: retryNextTurn,
-                        actions: [
-                            (
-                                action: conditional(
-                                    condition: All([
-                                        All([
-                                            Pred(hasItem(
-                                                item: "hint_radio",
-                                            )),
-                                            Pred(hasFlag(
-                                                flag: "hint-radio-on",
-                                            )),
-                                        ]),
-                                        Pred(hasFlag(
-                                            flag: "hal-module-in-crevice",
-                                        )),
-                                    ]),
-                                    actions: [
-                                        (
-                                            action: npcSays(
-                                                npc: "hint_radio_npc",
-                                                quote: "Whoops. That electronic bit fell way down in that crevice. Looks like you\'ll need something like a fishing line to pull it out. There must be **something** you can use around here.",
-                                            ),
-                                            priority: None,
-                                        ),
-                                    ],
-                                ),
-                                priority: None,
-                            ),
-                        ],
-                        note: Some("fishing line hint available"),
                     ),
                     priority: None,
                 ),
@@ -13889,12 +14660,14 @@
                         turns_ahead: 2,
                         condition: Any([
                             All([
-                                Pred(hasItem(
-                                    item: "hint_radio",
-                                )),
-                                Pred(hasFlag(
-                                    flag: "hint-radio-on",
-                                )),
+                                All([
+                                    Pred(hasItem(
+                                        item: "hint_radio",
+                                    )),
+                                    Pred(hasFlag(
+                                        flag: "hint-radio-on",
+                                    )),
+                                ]),
                                 All([
                                     Pred(missingFlag(
                                         flag: "woodland-gate-open",
@@ -13906,6 +14679,9 @@
                                         flag: "patio-gate-open",
                                     )),
                                 ]),
+                                Pred(hasVisited(
+                                    room: "stargate-room",
+                                )),
                                 Any([
                                     Pred(playerInRoom(
                                         room: "stargate-room",
@@ -13921,21 +14697,31 @@
                                     )),
                                 ]),
                             ]),
-                            Pred(hasFlag(
-                                flag: "portal-gun-powered",
-                            )),
+                            Any([
+                                Pred(hasFlag(
+                                    flag: "woodland-gate-open",
+                                )),
+                                Pred(hasFlag(
+                                    flag: "snowfield-gate-open",
+                                )),
+                                Pred(hasFlag(
+                                    flag: "patio-gate-open",
+                                )),
+                            ]),
                         ]),
                         on_false: retryNextTurn,
                         actions: [
                             (
                                 action: conditional(
                                     condition: All([
-                                        Pred(hasItem(
-                                            item: "hint_radio",
-                                        )),
-                                        Pred(hasFlag(
-                                            flag: "hint-radio-on",
-                                        )),
+                                        All([
+                                            Pred(hasItem(
+                                                item: "hint_radio",
+                                            )),
+                                            Pred(hasFlag(
+                                                flag: "hint-radio-on",
+                                            )),
+                                        ]),
                                         All([
                                             Pred(missingFlag(
                                                 flag: "woodland-gate-open",
@@ -13947,6 +14733,9 @@
                                                 flag: "patio-gate-open",
                                             )),
                                         ]),
+                                        Pred(hasVisited(
+                                            room: "stargate-room",
+                                        )),
                                         Any([
                                             Pred(playerInRoom(
                                                 room: "stargate-room",
@@ -13966,16 +14755,483 @@
                                         (
                                             action: npcSays(
                                                 npc: "hint_radio_npc",
-                                                quote: "The stargate seems to be tied to certain sites around the premises. It looks like there\'s something that you need to do at the receiving sites to be able to open those portals, though. Come to think of it, there was one of those ornate pillars at each of the other gate sites...",
+                                                quote: "The stargate seems to be tied to certain sites around the premises. It looks like there\'s something that you need to do at the receiving sites to be able to open those portals, though. Come to think of it, there was one of the ornate pillars with a plaque at each of the other gate sites...",
                                             ),
                                             priority: None,
                                         ),
                                     ],
+                                    false_actions: None,
                                 ),
                                 priority: None,
                             ),
                         ],
                         note: Some("stargate hint"),
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[HINT Radio] Find/Insert Vogon Poetry",
+            note: None,
+            only_once: true,
+            event: giveToNpc(
+                item: "invitation",
+                npc: "demerzel",
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: scheduleInIf(
+                        turns_ahead: 3,
+                        condition: Any([
+                            All([
+                                All([
+                                    Pred(hasItem(
+                                        item: "hint_radio",
+                                    )),
+                                    Pred(hasFlag(
+                                        flag: "hint-radio-on",
+                                    )),
+                                ]),
+                                Pred(missingFlag(
+                                    flag: "panic-room-open",
+                                )),
+                                Any([
+                                    Pred(playerInRoom(
+                                        room: "amble-office",
+                                    )),
+                                    Pred(playerInRoom(
+                                        room: "vip-bathroom",
+                                    )),
+                                ]),
+                            ]),
+                            Pred(hasFlag(
+                                flag: "panic-room-open",
+                            )),
+                        ]),
+                        on_false: retryNextTurn,
+                        actions: [
+                            (
+                                action: conditional(
+                                    condition: All([
+                                        All([
+                                            Pred(hasItem(
+                                                item: "hint_radio",
+                                            )),
+                                            Pred(hasFlag(
+                                                flag: "hint-radio-on",
+                                            )),
+                                        ]),
+                                        Pred(missingFlag(
+                                            flag: "panic-room-open",
+                                        )),
+                                        Any([
+                                            Pred(playerInRoom(
+                                                room: "amble-office",
+                                            )),
+                                            Pred(playerInRoom(
+                                                room: "vip-bathroom",
+                                            )),
+                                        ]),
+                                    ]),
+                                    actions: [
+                                        (
+                                            action: npcSays(
+                                                npc: "hint_radio_npc",
+                                                quote: "The rumor around here is that the last candidate was vaporized while sealed in the hidden Poetry Panic Room at the office, and they had the sole remaining elevator keycard with them. The Poetry Performer will panic if you try to make it perform some Vogon poetry. I\'m sure you can see where this is going.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    false_actions: None,
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        note: Some("poetry performer radio hint"),
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "HINT Radio: That Gonk Can Charge Your Battery",
+            note: None,
+            only_once: true,
+            event: takeItem(
+                item: "empty_battery",
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: scheduleInIf(
+                        turns_ahead: 2,
+                        condition: Any([
+                            All([
+                                All([
+                                    Pred(hasItem(
+                                        item: "hint_radio",
+                                    )),
+                                    Pred(hasFlag(
+                                        flag: "hint-radio-on",
+                                    )),
+                                ]),
+                                Pred(missingFlag(
+                                    flag: "portal-gun-powered",
+                                )),
+                                Pred(hasItem(
+                                    item: "empty_battery",
+                                )),
+                                Pred(withNpc(
+                                    npc: "gonk_droid",
+                                )),
+                            ]),
+                            Pred(hasFlag(
+                                flag: "got-charged-battery",
+                            )),
+                        ]),
+                        on_false: retryNextTurn,
+                        actions: [
+                            (
+                                action: conditional(
+                                    condition: All([
+                                        All([
+                                            Pred(hasItem(
+                                                item: "hint_radio",
+                                            )),
+                                            Pred(hasFlag(
+                                                flag: "hint-radio-on",
+                                            )),
+                                        ]),
+                                        Pred(missingFlag(
+                                            flag: "portal-gun-powered",
+                                        )),
+                                        Pred(hasItem(
+                                            item: "empty_battery",
+                                        )),
+                                        Pred(withNpc(
+                                            npc: "gonk_droid",
+                                        )),
+                                    ]),
+                                    actions: [
+                                        (
+                                            action: npcSays(
+                                                npc: "hint_radio_npc",
+                                                quote: "See that gonk droid clomping about over there? They can power or charge just about anything, from what I hear. Not much for conversation though, the gonks.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    false_actions: None,
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        note: Some("radio gives battery hint"),
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "Hint: Find Items to Build a Fire",
+            note: Some("schedule radio hint about building a fire"),
+            only_once: true,
+            event: useItem(
+                item: "plaque_2_frozen",
+                ability: read,
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: scheduleInIf(
+                        turns_ahead: 4,
+                        condition: Any([
+                            All([
+                                Pred(missingFlag(
+                                    flag: "campfire-lit",
+                                )),
+                                All([
+                                    Pred(hasItem(
+                                        item: "hint_radio",
+                                    )),
+                                    Pred(hasFlag(
+                                        flag: "hint-radio-on",
+                                    )),
+                                ]),
+                                Pred(playerInRoom(
+                                    room: "ice-pit",
+                                )),
+                            ]),
+                            Pred(hasFlag(
+                                flag: "campfire-lit",
+                            )),
+                        ]),
+                        on_false: retryNextTurn,
+                        actions: [
+                            (
+                                action: conditional(
+                                    condition: All([
+                                        Pred(missingFlag(
+                                            flag: "campfire-lit",
+                                        )),
+                                        All([
+                                            Pred(hasItem(
+                                                item: "hint_radio",
+                                            )),
+                                            Pred(hasFlag(
+                                                flag: "hint-radio-on",
+                                            )),
+                                        ]),
+                                        Pred(playerInRoom(
+                                            room: "ice-pit",
+                                        )),
+                                    ]),
+                                    actions: [
+                                        (
+                                            action: npcSays(
+                                                npc: "hint_radio_npc",
+                                                quote: "To melt that pillar, you\'ll need to drop some firewood here and light it with something.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    false_actions: None,
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        note: Some("radio gives campfire hint"),
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "Firewood HINT",
+            note: Some("HINT radio: add firewood hint to scheduler"),
+            only_once: true,
+            event: enterRoom(
+                room: "snow-camp",
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: scheduleInIf(
+                        turns_ahead: 4,
+                        condition: Any([
+                            All([
+                                All([
+                                    Pred(hasItem(
+                                        item: "hint_radio",
+                                    )),
+                                    Pred(hasFlag(
+                                        flag: "hint-radio-on",
+                                    )),
+                                ]),
+                                Pred(hasFlag(
+                                    flag: "tried-read-plaque-2",
+                                )),
+                                Pred(missingFlag(
+                                    flag: "campfire-lit",
+                                )),
+                                Pred(missingItem(
+                                    item: "firewood",
+                                )),
+                                Pred(playerInRoom(
+                                    room: "snow-camp",
+                                )),
+                            ]),
+                            Any([
+                                Pred(hasFlag(
+                                    flag: "read-plaque-2",
+                                )),
+                                Pred(hasFlag(
+                                    flag: "campfire-lit",
+                                )),
+                                Pred(hasItem(
+                                    item: "firewood",
+                                )),
+                            ]),
+                        ]),
+                        on_false: retryNextTurn,
+                        actions: [
+                            (
+                                action: conditional(
+                                    condition: All([
+                                        All([
+                                            Pred(hasItem(
+                                                item: "hint_radio",
+                                            )),
+                                            Pred(hasFlag(
+                                                flag: "hint-radio-on",
+                                            )),
+                                        ]),
+                                        Pred(hasFlag(
+                                            flag: "tried-read-plaque-2",
+                                        )),
+                                        Pred(missingFlag(
+                                            flag: "campfire-lit",
+                                        )),
+                                        Pred(missingItem(
+                                            item: "firewood",
+                                        )),
+                                        Pred(playerInRoom(
+                                            room: "snow-camp",
+                                        )),
+                                    ]),
+                                    actions: [
+                                        (
+                                            action: npcSays(
+                                                npc: "hint_radio_npc",
+                                                quote: "Looks like the researchers didn\'t get their fire lit before the dog-Thing got to them. Bad day for them, but maybe good for you. Could you move the firewood down into the ice pit to melt the ice around the frozen pillar?",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    false_actions: None,
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        note: Some("HINT radio: deliver firewood hint"),
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[HINT Available] Make A Fishing Line",
+            note: Some("makes hint available when HAL module trapped in crevice"),
+            only_once: true,
+            event: useItemOnItem(
+                tool: "crowbar",
+                target: "vending_machine",
+                interaction: open,
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: scheduleInIf(
+                        turns_ahead: 2,
+                        condition: Any([
+                            All([
+                                All([
+                                    Pred(hasItem(
+                                        item: "hint_radio",
+                                    )),
+                                    Pred(hasFlag(
+                                        flag: "hint-radio-on",
+                                    )),
+                                ]),
+                                Pred(hasFlag(
+                                    flag: "hal-module-in-crevice",
+                                )),
+                            ]),
+                            Pred(hasFlag(
+                                flag: "module-2-retrieved",
+                            )),
+                        ]),
+                        on_false: retryNextTurn,
+                        actions: [
+                            (
+                                action: conditional(
+                                    condition: All([
+                                        All([
+                                            Pred(hasItem(
+                                                item: "hint_radio",
+                                            )),
+                                            Pred(hasFlag(
+                                                flag: "hint-radio-on",
+                                            )),
+                                        ]),
+                                        Pred(hasFlag(
+                                            flag: "hal-module-in-crevice",
+                                        )),
+                                    ]),
+                                    actions: [
+                                        (
+                                            action: npcSays(
+                                                npc: "hint_radio_npc",
+                                                quote: "Whoops. That electronic bit fell way down in that crevice. Looks like you\'ll need something like a fishing line to pull it out. There must be **something** you can use around here.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    false_actions: None,
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        note: Some("fishing line hint available"),
+                    ),
+                    priority: None,
+                ),
+            ],
+        ),
+        (
+            name: "[HINT] Towel Cleans Plaque 1",
+            note: None,
+            only_once: true,
+            event: takeItem(
+                item: "towel",
+            ),
+            conditions: All([]),
+            actions: [
+                (
+                    action: scheduleInIf(
+                        turns_ahead: 2,
+                        condition: Any([
+                            All([
+                                All([
+                                    Pred(hasItem(
+                                        item: "hint_radio",
+                                    )),
+                                    Pred(hasFlag(
+                                        flag: "hint-radio-on",
+                                    )),
+                                ]),
+                                Pred(missingFlag(
+                                    flag: "read-plaque-1",
+                                )),
+                            ]),
+                            Pred(hasFlag(
+                                flag: "read-plaque-1",
+                            )),
+                        ]),
+                        on_false: retryNextTurn,
+                        actions: [
+                            (
+                                action: conditional(
+                                    condition: All([
+                                        All([
+                                            Pred(hasItem(
+                                                item: "hint_radio",
+                                            )),
+                                            Pred(hasFlag(
+                                                flag: "hint-radio-on",
+                                            )),
+                                        ]),
+                                        Pred(missingFlag(
+                                            flag: "read-plaque-1",
+                                        )),
+                                    ]),
+                                    actions: [
+                                        (
+                                            action: npcSays(
+                                                npc: "hint_radio_npc",
+                                                quote: "Towels can be awfully handy for cleaning off grimy things. Just sayin\'.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    false_actions: None,
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        note: Some("towels can clean hint"),
                     ),
                     priority: None,
                 ),
@@ -14001,7 +15257,7 @@
         (
             name: "Follower of the Shoe",
             note: Some("locks player into the shoe sect"),
-            only_once: true,
+            only_once: false,
             event: takeFromItem(
                 loot: "messiah_shoe",
                 container: "messiah_kit",
@@ -14009,40 +15265,101 @@
             conditions: All([]),
             actions: [
                 (
-                    action: showMessage(
-                        text: "[[hl]]You are now a follower of the [[item]]Shoe[[/item]].[[/hl]]",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: setItemMovability(
-                        item: "messiah_gourd",
-                        movability: fixed(
-                            reason: "You are already a follower of the Shoe. Your faith in the Sanctified Sandal shall not be shaken.",
-                        ),
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: awardPoints(
-                        amount: 5,
-                        reason: "Became a Follower of the Shoe",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: addFlag(
-                        flag: simple(
-                            name: "sect-shoe",
-                        ),
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: addSpinnerWedge(
-                        spinner: "ambientWoodland",
-                        text: "Far above, the trees seem to whisper: \"Yesss. Yes! The Shoe is the Way.\" ",
-                        width: 1,
+                    action: conditional(
+                        condition: Pred(missingFlag(
+                            flag: "warned-about-sects",
+                        )),
+                        actions: [
+                            (
+                                action: showMessage(
+                                    text: "[[bright-red]][[b]][[i]]…before fully taking it into your grasp, you have a moment of doubt…[[/i]][[/b]][[/bright-red]]",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: showMessage(
+                                    text: "Is your faith [[u]]unshakable[[/u]]? Once you take either the [[item]]Shoe[[/item]] or the [[item]]Gourd[[/item]], there is no going back.",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: addFlag(
+                                    flag: simple(
+                                        name: "warned-about-sects",
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: despawnItem(
+                                    item: "messiah_shoe",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: spawnItemInContainer(
+                                    item: "messiah_shoe",
+                                    container: "messiah_kit",
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        false_actions: Some([
+                            (
+                                action: conditional(
+                                    condition: All([
+                                        Pred(missingFlag(
+                                            flag: "sect-shoe",
+                                        )),
+                                        Pred(missingFlag(
+                                            flag: "sect-gourd",
+                                        )),
+                                    ]),
+                                    actions: [
+                                        (
+                                            action: showMessage(
+                                                text: "[[hl]]You are now a follower of the [[item]]Shoe[[/item]].[[/hl]]",
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: setItemMovability(
+                                                item: "messiah_gourd",
+                                                movability: fixed(
+                                                    reason: "You are already a follower of the Shoe. Your faith in the Sanctified Sandal shall not be shaken.",
+                                                ),
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: awardPoints(
+                                                amount: 5,
+                                                reason: "Became a Follower of the Shoe",
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: addFlag(
+                                                flag: simple(
+                                                    name: "sect-shoe",
+                                                ),
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: addSpinnerWedge(
+                                                spinner: "ambientWoodland",
+                                                text: "Far above, the trees seem to whisper: \"Yesss. Yes! The Shoe is the Way.\" ",
+                                                width: 1,
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    false_actions: None,
+                                ),
+                                priority: None,
+                            ),
+                        ]),
                     ),
                     priority: None,
                 ),
@@ -14051,7 +15368,7 @@
         (
             name: "Follower of the Gourd",
             note: Some("locks player into the gourd sect"),
-            only_once: true,
+            only_once: false,
             event: takeFromItem(
                 loot: "messiah_gourd",
                 container: "messiah_kit",
@@ -14059,40 +15376,101 @@
             conditions: All([]),
             actions: [
                 (
-                    action: showMessage(
-                        text: "[[b]]You are now a follower of the [[item]]Gourd[[/item]].[[/b]]",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: setItemMovability(
-                        item: "messiah_shoe",
-                        movability: fixed(
-                            reason: "You are already a follower of the Gourd. Your faith in the Vaunted Vegetable shall not be shaken.",
-                        ),
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: awardPoints(
-                        amount: 5,
-                        reason: "Became a Follower of the Gourd",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: addFlag(
-                        flag: simple(
-                            name: "sect-gourd",
-                        ),
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: addSpinnerWedge(
-                        spinner: "ambientWoodland",
-                        text: "Far above, the trees seem to whisper: \"Yesss. Yes! The Gourd is the Way.\" ",
-                        width: 1,
+                    action: conditional(
+                        condition: Pred(missingFlag(
+                            flag: "warned-about-sects",
+                        )),
+                        actions: [
+                            (
+                                action: showMessage(
+                                    text: "[[bright-red]][[b]][[i]]…before fully taking it into your grasp, you have a moment of doubt…[[/i]][[/b]][[/bright-red]]",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: showMessage(
+                                    text: "Is your faith [[u]]unshakable[[/u]]? Once you take either the [[item]]Shoe[[/item]] or the [[item]]Gourd[[/item]], there is no going back.",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: addFlag(
+                                    flag: simple(
+                                        name: "warned-about-sects",
+                                    ),
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: despawnItem(
+                                    item: "messiah_gourd",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: spawnItemInContainer(
+                                    item: "messiah_gourd",
+                                    container: "messiah_kit",
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        false_actions: Some([
+                            (
+                                action: conditional(
+                                    condition: All([
+                                        Pred(missingFlag(
+                                            flag: "sect-shoe",
+                                        )),
+                                        Pred(missingFlag(
+                                            flag: "sect-gourd",
+                                        )),
+                                    ]),
+                                    actions: [
+                                        (
+                                            action: showMessage(
+                                                text: "[[b]]You are now a follower of the [[item]]Gourd[[/item]].[[/b]]",
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: setItemMovability(
+                                                item: "messiah_shoe",
+                                                movability: fixed(
+                                                    reason: "You are already a follower of the Gourd. Your faith in the Vaunted Vegetable shall not be shaken.",
+                                                ),
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: awardPoints(
+                                                amount: 5,
+                                                reason: "Became a Follower of the Gourd",
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: addFlag(
+                                                flag: simple(
+                                                    name: "sect-gourd",
+                                                ),
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: addSpinnerWedge(
+                                                spinner: "ambientWoodland",
+                                                text: "Far above, the trees seem to whisper: \"Yesss. Yes! The Gourd is the Way.\" ",
+                                                width: 1,
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    false_actions: None,
+                                ),
+                                priority: None,
+                            ),
+                        ]),
                     ),
                     priority: None,
                 ),
@@ -14235,72 +15613,6 @@
                 (
                     action: showMessage(
                         text: "[[u]]NOW[[/u]] you\'re a frood who really[[b]] \"knows where his towel is\"! [[/b]]",
-                    ),
-                    priority: None,
-                ),
-            ],
-        ),
-        (
-            name: "[HINT] Towel Cleans Plaque 1",
-            note: None,
-            only_once: true,
-            event: takeItem(
-                item: "towel",
-            ),
-            conditions: All([]),
-            actions: [
-                (
-                    action: scheduleInIf(
-                        turns_ahead: 2,
-                        condition: Any([
-                            All([
-                                All([
-                                    Pred(hasItem(
-                                        item: "hint_radio",
-                                    )),
-                                    Pred(hasFlag(
-                                        flag: "hint-radio-on",
-                                    )),
-                                ]),
-                                Pred(missingFlag(
-                                    flag: "read-plaque-1",
-                                )),
-                            ]),
-                            Pred(hasFlag(
-                                flag: "read-plaque-1",
-                            )),
-                        ]),
-                        on_false: retryNextTurn,
-                        actions: [
-                            (
-                                action: conditional(
-                                    condition: All([
-                                        All([
-                                            Pred(hasItem(
-                                                item: "hint_radio",
-                                            )),
-                                            Pred(hasFlag(
-                                                flag: "hint-radio-on",
-                                            )),
-                                        ]),
-                                        Pred(missingFlag(
-                                            flag: "read-plaque-1",
-                                        )),
-                                    ]),
-                                    actions: [
-                                        (
-                                            action: npcSays(
-                                                npc: "hint_radio_npc",
-                                                quote: "Towels can be awfully handy for cleaning off grimy things. Just sayin\'.",
-                                            ),
-                                            priority: None,
-                                        ),
-                                    ],
-                                ),
-                                priority: None,
-                            ),
-                        ],
-                        note: Some("towels can clean hint"),
                     ),
                     priority: None,
                 ),

--- a/amble_engine/data/world.ron
+++ b/amble_engine/data/world.ron
@@ -367,7 +367,7 @@
         (
             id: "gourd-shrine",
             name: "Shrine of the Holy Gourd",
-            desc: "This chapel glows with warm amber light filtered through bottle-green glass, giving everything the reverent complexion of very expensive soup. Vines curl around fluted pillars, seed motifs repeat across the floor, and at the far end a circular [[item]]Harvest Altar[[/item]] stands beneath a domed canopy. A velvet-lined recess at its center is being guarded by atmosphere alone, which in this room seems to consider itself armed. The air smells of beeswax, autumn leaves, and the smug serenity of people who believe a vegetable solved the major philosophical questions decades ago.",
+            desc: "This chapel glows with warm amber light filtered through bottle-green glass, giving everything the reverent complexion of very expensive soup. Vines curl around fluted pillars, seed motifs repeat across the floor, and at the far end a circular [[item]]Harvest Altar[[/item]] stands beneath a domed canopy. A velvet-lined recess at its center is being guarded by atmosphere alone, which in this room seems to consider itself armed. The air smells of beeswax, autumn leaves, and the smug serenity of people who believe a vegetable solved the major philosophical questions decades ago. Near the entry, a [[item]]hymn board[[//item]] spells out the plan for the day\'s worship while an [[item]]abacus[[/item]] stands ready to count the devoted.",
             visited: false,
             exits: [
                 (
@@ -759,11 +759,11 @@
         (
             id: "main-lobby",
             name: "Main Lobby",
-            desc: "The lobby is clinically clean in a way that feels suspicious. A slightly humming vending machine stands beside an empty podium. Softly glowing script over an archway on the far wall reads \'Elevator Access\'. To one side, there is floor-to-ceiling frosted glass with an etched door at the farthest end from the entrance. Opposite that, the smell of searing beef wafts from a broad entryway flanked by a wobbly sign.",
+            desc: "The lobby is clinically clean in a way that feels suspicious. A slightly humming vending machine stands beside an empty podium. Softly glowing script over an archway on the far wall reads [[i]][[blue]]Lift Access[[/blue]][[/i]] where a few short steps lead up to an elevator bank. To one side, there is floor-to-ceiling frosted glass with an etched door at the farthest end from the entrance. Opposite that, the smell of searing beef wafts from a broad entryway flanked by a wobbly sign.",
             visited: false,
             exits: [
                 (
-                    direction: "elevator access",
+                    direction: "lift access",
                     to: "lift-bank-main",
                     hidden: false,
                     locked: false,
@@ -790,7 +790,7 @@
                     barred_message: None,
                 ),
                 (
-                    direction: "etched door",
+                    direction: "frosted glass door",
                     to: "amble-office",
                     hidden: false,
                     locked: false,
@@ -867,7 +867,7 @@
                     desc: Some("A typical wooden podium used to welcome incoming visitors, and just as typically vacant. It bears an emblem that reads: [[hl]][[i]]Welcome, Candidate[[/i][[/hl]]."),
                 ),
                 (
-                    name: "Etched Door",
+                    name: "Frosted Glass Door",
                     desc: Some("A frosted glass office door, etched with: [[box:MAIN OFFICE]]Amble Adventures[[/box]]"),
                 ),
             ],
@@ -1175,7 +1175,7 @@
         (
             id: "shoe-shrine",
             name: "Shrine of the Holy Shoe",
-            desc: "A long, narrow chapel of polished oak and stern symmetry stretches before you, lit by stained glass windows that cast sandal-shaped colors across the floor. At the far end, on a raised [[item]]Sandal Altar[[/item]], a velvet-lined recess sits at attention beneath a cone of buttery light. Rows of pews face forward with the crisp obedience of well-behaved feet. The air carries beeswax, old leather, and the faint, intoxicating scent of absolute certainty rubbed to a shine.",
+            desc: "A long, narrow chapel of polished oak and stern symmetry stretches before you, lit by stained glass windows that cast sandal-shaped colors across the floor. A [[item]]liturgy board[[/item]] announces the day\'s plan near the entryway, with the obligatory [[item]]donation box[[/item]] mounted below it. At the far end, on a raised [[item]]Sandal Altar[[/item]], a velvet-lined recess sits at attention beneath a cone of buttery light. Rows of pews face forward with the crisp obedience of well-behaved feet. The air carries beeswax, old leather, and the faint, intoxicating scent of absolute certainty rubbed to a shine.",
             visited: false,
             exits: [
                 (
@@ -1192,7 +1192,7 @@
             scenery: [
                 (
                     name: "Stained Glass",
-                    desc: Some("The windows depict the Sacred Sandal performing small but decisive miracles: crossing deserts, toppling heretics, and in one panel apparently inventing left and right."),
+                    desc: Some("The windows depict the Sacred Sandal performing small but decisive miracles: crossing deserts, toppling heretics, and in one panel apparently inventing the idea of [[b]]left[[/b]] and [[b]]right[[/b]]."),
                 ),
                 (
                     name: "Pews",
@@ -7168,7 +7168,7 @@
         ),
         (
             name: "[Aperture-Lab]",
-            note: None,
+            note: Some("barehanded \'take\' not possible - it\'s on fire"),
             only_once: false,
             event: takeItem(
                 item: "flaming_invitation",
@@ -8690,6 +8690,10 @@
                 Pred(withNpc(
                     npc: "demerzel",
                 )),
+                Pred(npcHasItem(
+                    npc: "demerzel",
+                    item: "lost_and_found_key",
+                )),
             ]),
             actions: [
                 (
@@ -9339,34 +9343,43 @@
             conditions: All([]),
             actions: [
                 (
-                    action: showMessage(
-                        text: "A chime echoes through the lobby. \"Candidates: Please do not loiter in the lobby,\" intones an overhead voice.",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: scheduleInIf(
-                        turns_ahead: 3,
-                        condition: Pred(playerInRoom(
-                            room: "main-lobby",
-                        )),
-                        on_false: cancel,
+                    action: scheduleIn(
+                        turns_ahead: 2,
                         actions: [
                             (
                                 action: showMessage(
-                                    text: "The chime sounds again. \"Candidates: We **said** not to loiter in the lobby,\" says the voice, in more of an annoyed tone.",
+                                    text: "A chime echoes through the lobby. \"Candidates: Please do not loiter in the lobby,\" intones an overhead voice.",
                                 ),
                                 priority: None,
                             ),
                             (
-                                action: awardPoints(
-                                    amount: -1,
-                                    reason: "Ignored the lobby loitering reminder",
+                                action: scheduleInIf(
+                                    turns_ahead: 5,
+                                    condition: Pred(playerInRoom(
+                                        room: "main-lobby",
+                                    )),
+                                    on_false: cancel,
+                                    actions: [
+                                        (
+                                            action: showMessage(
+                                                text: "The chime sounds again. \"Candidates: We **said** not to loiter in the lobby,\" says the voice, in more of an annoyed tone.",
+                                            ),
+                                            priority: None,
+                                        ),
+                                        (
+                                            action: awardPoints(
+                                                amount: -1,
+                                                reason: "Ignored the lobby loitering warning",
+                                            ),
+                                            priority: None,
+                                        ),
+                                    ],
+                                    note: Some("lobby loitering penalty"),
                                 ),
                                 priority: None,
                             ),
                         ],
-                        note: Some("lobby loitering reminder"),
+                        note: Some("lobby loitering warning"),
                     ),
                     priority: None,
                 ),
@@ -9455,7 +9468,7 @@
                 (
                     action: awardPoints(
                         amount: 3,
-                        reason: "Fished the zircon tweezers out of the vending machine",
+                        reason: "Fished the zircon tweezers out of the vending machine crevice",
                     ),
                     priority: None,
                 ),
@@ -11090,51 +11103,67 @@
                 target: "security_locker",
                 action: break,
             ),
-            conditions: Pred(missingFlag(
-                flag: "unlocked-security-crate",
-            )),
+            conditions: All([]),
             actions: [
                 (
-                    action: despawnItem(
-                        item: "security_locker",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: spawnItemCurrentRoom(
-                        item: "crowbar",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: spawnItemCurrentRoom(
-                        item: "security_log",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: spawnItemCurrentRoom(
-                        item: "shattered_vial",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: spawnItemCurrentRoom(
-                        item: "initech_mug",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: showMessage(
-                        text: "With a few hefty blows, you manage to break the lock haft completely off of the security locker -- well after a few misses had already caved in the lid and destroyed it, but you were having fun. It looks like you broke a couple of the items that were inside in the process.",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: addSpinnerWedge(
-                        spinner: "ambientInterior",
-                        text: "PA Announcement: \'Someone broke into the security locker on the dock. Mind your belongings and report any suspicious activity to security.\'",
-                        width: 1,
+                    action: conditional(
+                        condition: Pred(missingFlag(
+                            flag: "unlocked-security-crate",
+                        )),
+                        actions: [
+                            (
+                                action: despawnItem(
+                                    item: "security_locker",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: spawnItemCurrentRoom(
+                                    item: "crowbar",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: spawnItemCurrentRoom(
+                                    item: "security_log",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: spawnItemCurrentRoom(
+                                    item: "shattered_vial",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: spawnItemCurrentRoom(
+                                    item: "initech_mug",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: showMessage(
+                                    text: "With a few hefty blows, you manage to break the lock haft completely off of the security locker -- well after a few misses had already caved in the lid and destroyed it, but you were having fun. It looks like you broke a couple of the items that were inside in the process.",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: addSpinnerWedge(
+                                    spinner: "ambientInterior",
+                                    text: "PA Announcement: \'Someone broke into the security locker on the dock. Mind your belongings and report any suspicious activity to security.\'",
+                                    width: 1,
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        false_actions: Some([
+                            (
+                                action: showMessage(
+                                    text: "Despite already having unlocked the crate, you bash it a few times for emphasis.",
+                                ),
+                                priority: None,
+                            ),
+                        ]),
                     ),
                     priority: None,
                 ),
@@ -11148,51 +11177,67 @@
                 target: "security_locker",
                 action: burn,
             ),
-            conditions: Pred(missingFlag(
-                flag: "unlocked-security-crate",
-            )),
+            conditions: All([]),
             actions: [
                 (
-                    action: despawnItem(
-                        item: "security_locker",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: spawnItemCurrentRoom(
-                        item: "crowbar",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: spawnItemCurrentRoom(
-                        item: "burned_security_log",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: spawnItemCurrentRoom(
-                        item: "strange_liquid",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: spawnItemCurrentRoom(
-                        item: "initech_mug",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: showMessage(
-                        text: "WHOOOOOMP! The locker, which you now realize may have been made from the solid magnesium magnolia trees of Siwenna, goes up in a white hot flash -- taking your eyebrows with it. It looks like *some* of the items inside weren\'t flammable.",
-                    ),
-                    priority: None,
-                ),
-                (
-                    action: addSpinnerWedge(
-                        spinner: "ambientInterior",
-                        text: "PA Announcement: \'Someone used an Arson-Aid to torch the security locker at the loading dock. An investigation is underway. Report anyone with scorched clothes or missing eyebrows to security.\'",
-                        width: 1,
+                    action: conditional(
+                        condition: Pred(missingFlag(
+                            flag: "unlocked-security-crate",
+                        )),
+                        actions: [
+                            (
+                                action: despawnItem(
+                                    item: "security_locker",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: spawnItemCurrentRoom(
+                                    item: "crowbar",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: spawnItemCurrentRoom(
+                                    item: "burned_security_log",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: spawnItemCurrentRoom(
+                                    item: "strange_liquid",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: spawnItemCurrentRoom(
+                                    item: "initech_mug",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: showMessage(
+                                    text: "WHOOOOOMP! The locker, which you now realize may have been made from the solid magnesium magnolia trees of Siwenna, goes up in a white hot flash -- taking your eyebrows with it. It looks like *some* of the items inside weren\'t flammable.",
+                                ),
+                                priority: None,
+                            ),
+                            (
+                                action: addSpinnerWedge(
+                                    spinner: "ambientInterior",
+                                    text: "PA Announcement: \'Someone used an Arson-Aid to torch the security locker at the loading dock. An investigation is underway. Report anyone with scorched clothes or missing eyebrows to security.\'",
+                                    width: 1,
+                                ),
+                                priority: None,
+                            ),
+                        ],
+                        false_actions: Some([
+                            (
+                                action: showMessage(
+                                    text: "Strange… it seems like this crate should burn easily, but somehow it doesn\'t.",
+                                ),
+                                priority: None,
+                            ),
+                        ]),
                     ),
                     priority: None,
                 ),
@@ -15770,6 +15815,19 @@
             )),
             finished_when: hasFlag(
                 flag: "got-visitor-pass",
+            ),
+            failed_when: None,
+        ),
+        (
+            id: "access-lost-and-found",
+            name: "Gain Access to Lost and Found",
+            description: "There is a Lost and Found box in the office, and Demerzel has the key. When she\'s impressed enough with your progress, she\'ll give it to you.",
+            group: required,
+            activate_when: Some(reachedRoom(
+                room: "amble-office",
+            )),
+            finished_when: hasFlag(
+                flag: "lost-and-found-opened",
             ),
             failed_when: None,
         ),

--- a/amble_engine/src/loader/worlddef.rs
+++ b/amble_engine/src/loader/worlddef.rs
@@ -502,12 +502,20 @@ fn action_from_def(def: &ActionKind) -> Result<TriggerAction> {
             npc_id: npc.clone().into(),
             patch: npc_patch_from_def(patch),
         },
-        ActionKind::Conditional { condition, actions } => TriggerAction::Conditional {
+        ActionKind::Conditional {
+            condition,
+            actions,
+            false_actions,
+        } => TriggerAction::Conditional {
             condition: condition_expr_from_def(condition),
             actions: actions
                 .iter()
                 .map(scripted_action_from_def)
                 .collect::<Result<Vec<_>>>()?,
+            false_actions: false_actions
+                .as_ref()
+                .map(|actions| actions.iter().map(scripted_action_from_def).collect::<Result<Vec<_>>>())
+                .transpose()?,
         },
         ActionKind::ScheduleIn {
             turns_ahead,

--- a/amble_engine/src/trigger/action.rs
+++ b/amble_engine/src/trigger/action.rs
@@ -151,6 +151,7 @@ pub enum TriggerAction {
     Conditional {
         condition: EventCondition,
         actions: Vec<ScriptedAction>,
+        false_actions: Option<Vec<ScriptedAction>>,
     },
     /// Schedules a list of actions to fire after a specified number of turns.
     ScheduleIn {
@@ -313,9 +314,17 @@ pub fn dispatch_action(world: &mut AmbleWorld, view: &mut View, scripted: &Scrip
         AddFlag(flag) => add_flag_with_priority(world, view, flag, *priority),
         RemoveFlag(flag) => remove_flag_with_priority(world, view, flag, *priority),
         AwardPoints { amount, reason } => award_points_with_priority(world, view, *amount, reason, *priority),
-        Conditional { condition, actions } => {
+        Conditional {
+            condition,
+            actions,
+            false_actions,
+        } => {
             if condition.eval(world) {
                 for nested in actions {
+                    dispatch_action(world, view, nested)?;
+                }
+            } else if let Some(false_actions) = false_actions {
+                for nested in false_actions {
                     dispatch_action(world, view, nested)?;
                 }
             }

--- a/amble_engine/src/trigger/action/tests.rs
+++ b/amble_engine/src/trigger/action/tests.rs
@@ -941,6 +941,7 @@ fn dispatch_action_conditional_executes_nested_actions_when_condition_true() {
         actions: vec![ScriptedAction::new(TriggerAction::ShowMessage(
             "Conditional fired".into(),
         ))],
+        false_actions: None,
     });
 
     dispatch_action(&mut world, &mut view, &action).unwrap();
@@ -965,10 +966,44 @@ fn dispatch_action_conditional_skips_actions_when_condition_false() {
         actions: vec![ScriptedAction::new(TriggerAction::ShowMessage(
             "Should not appear".into(),
         ))],
+        false_actions: None,
     });
 
     dispatch_action(&mut world, &mut view, &action).unwrap();
 
+    assert!(view.items.iter().all(|entry| {
+        !matches!(
+            &entry.view_item,
+            ViewItem::TriggeredEvent(msg) if msg.contains("Should not appear")
+        )
+    }));
+}
+
+#[test]
+fn dispatch_action_conditional_executes_false_branch_when_condition_false() {
+    let (mut world, _, _) = build_test_world();
+    world.player.flags.insert(Flag::simple("hint", world.turn_count));
+    let mut view = View::new();
+
+    let action = ScriptedAction::new(TriggerAction::Conditional {
+        condition: crate::scheduler::EventCondition::Trigger(crate::trigger::TriggerCondition::MissingFlag(
+            "hint".into(),
+        )),
+        actions: vec![ScriptedAction::new(TriggerAction::ShowMessage(
+            "Should not appear".into(),
+        ))],
+        false_actions: Some(vec![ScriptedAction::new(TriggerAction::ShowMessage(
+            "False branch fired".into(),
+        ))]),
+    });
+
+    dispatch_action(&mut world, &mut view, &action).unwrap();
+
+    assert!(
+        view.items.iter().any(
+            |entry| matches!(&entry.view_item, ViewItem::TriggeredEvent(msg) if msg.contains("False branch fired"))
+        )
+    );
     assert!(view.items.iter().all(|entry| {
         !matches!(
             &entry.view_item,

--- a/amble_script/data/Amble/areas/bldg_main_floor/events/lab_fire.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/events/lab_fire.amble
@@ -57,7 +57,8 @@ item foam_fire {
 # Triggers
 # ========================================
 trigger "[Aperture-Lab]"
-when take flaming_invitation {
+note "barehanded 'take' not possible - it's on fire"
+when take flaming_invitation  {
     do replace drop item flaming_invitation with flaming_invitation
     do show "You burn your hand and drop the burning document on the floor. It looks like it might be an Amble Adventures invitation."
     do damage player 3 cause "played with fire"

--- a/amble_script/data/Amble/areas/bldg_main_floor/npcs/cmot_dibbler.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/npcs/cmot_dibbler.amble
@@ -72,5 +72,11 @@ when give item initech_mug to npc cmot_dibbler {
     do npc says cmot_dibbler "Whoa! Me favorite mug from the lads down at Initech?! Where did it turn up? Ah -- no matter, really. I still haven't figured out how to open the bloody thing, making it somewhat useless. Here -- seems fitting I give you this useless gizmo as a more-than-fair trade."
     do give item hal_module_3 to player from npc cmot_dibbler
     do add flag module-3-found
-    do award points 5 reason "Traded the Initech mug for HAL's third module"
+
+    # Don't give the identity of the gizmo away prematurely!
+    if flag in progress hal-reboot {
+        do award points 5 reason "Traded the Initech mug for HAL's third module"
+    } else {
+        do award points 5 reason "Traded the Initech mug for some electronic gizmo."
+    }
 }

--- a/amble_script/data/Amble/areas/bldg_main_floor/npcs/gonk_droid.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/npcs/gonk_droid.amble
@@ -37,8 +37,8 @@ item charged_battery {
 }
 
 item gonk_family_photo {
-    name "Gonk's Family Photo"
-    desc "A slightly scorched photograph of the gonk droid with its family: a PC power supply, a D-cell, and a set of adorable AAA triplets."
+    name "Fading Photograph"
+    desc "A slightly scorched and faded photograph depicts the gonk droid with its family: a PC power supply, a D-cell, and a set of adorable AAA triplets."
     movability free
     location npc gonk_droid
     text "Brains Anonymous Energy Division Picnic — For Staff & Families of Room AA-3B. (added below: \"Just hours before the Candidate reported for load test...\")"
@@ -49,12 +49,20 @@ item gonk_family_photo {
 # Triggers
 # ========================================
 
-trigger "[Gonk Droid] Happy When Family Photo Inspected" only once
+trigger "[Gonk Droid] Photo Taken"
+when take gonk_family_photo from npc gonk_droid {
+    do show "The gonk droid excitedly points out something on the photograph. Or would, if it had anything to point with."
+    do npc says gonk_droid "Gonk! →"
+}
+
+trigger "[Gonk Droid] Happy When Family Photo Inspected"
 when look at item gonk_family_photo {
     do npc says gonk_droid "GONK gonk!"
     do show "The gonk droid totters with pride as you view its family photo."
-    do award points 2 reason "Admired the gonk droid's family photo"
-    do add flag made-gonk-proud
+    if missing flag made-gonk-proud {
+        do award points 2 reason "Admired the gonk droid's family photo"
+        do add flag made-gonk-proud
+    }
 }
 
 trigger "[Gonk Droid]"

--- a/amble_script/data/Amble/areas/bldg_main_floor/npcs/receptionist.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/npcs/receptionist.amble
@@ -8,18 +8,18 @@ npc demerzel {
 
 Demerzel is a positronic android, and has been continuously online for thousands of years -- working at reception desks going back as far as Pharoah Ramses II. At her position at Amble Adentures, she also serves as a firewall, preventing any clearly unworthy Candidates from making any progress through the system."""
     location room amble-office
-    max_hp 20
-    state normal
-    dialogue bored {
+    max_hp 200
+    state custom unhelpful
+    dialogue custom impressed {
         "Impressive work, getting the keycard. Many of our previous applicants have died in the attempt. Very promising! The evaluator will be pleased. Strong lateral thinking and slight psychosis are essential for such a dangerous position, as I'm sure you are aware."
         "You can now use the elevator to find room AA-3B for the next stage of your initiation."
     }
-    dialogue happy {
+    dialogue custom helpful {
         "Terribly sorry to report that we are in a bit of trouble here today. The last candidate was inconsiderate enough to take the elevator access card into the poetry panic room just before he melted, and we can't retrieve it."
         "The elevator keycard last pinged our system from the Poetry Panic Room, but it is sealed, and concealed behind the whiteboard. Only the Poetry Performer Unit can grant access."
         "Sorry I didn't immediately recognize that you are a Candidate, but most of your competitors have been blurry, furry, or out of phase."
     }
-    dialogue normal {
+    dialogue custom unhelpful {
         "(She rolls her eyes.) Please wait quietly out of the way. There are people with invitations who should be assisted first."
         "(She simply ignores you.)"
         "(She continues doing her job -- which appears to be pointedly ignoring anyone without an invitation.)"
@@ -38,7 +38,7 @@ when always {
         missing flag got-visitor-pass,
         missing flag got-elevator-keycard,
     ) {
-        do set npc state demerzel normal
+        do set npc state demerzel custom:unhelpful
     }
 }
 
@@ -49,7 +49,7 @@ when always {
         has flag got-visitor-pass,
         missing flag got-elevator-keycard,
     ) {
-        do set npc state demerzel happy
+        do set npc state demerzel custom:helpful
     }
 }
 
@@ -59,7 +59,7 @@ when give item invitation to npc demerzel {
     do despawn item invitation
     do spawn item visitor_pass in inventory
     do award points 10 reason "Secured a visitor pass from the receptionist"
-    do set npc state demerzel happy
+    do set npc state demerzel custom:helpful
     do show "The robotic receptionist initially looked at you with the disdain of someone who spends all day waiting on people who are waiting on someone else, but her demeanor and even appearance immediately became welcoming once she noticed the invitation in your hand. Deftly, she takes it from you, scrutinizes it intently, and slips it into a desktop document vaporizer.\n\nShe then hands you a laminated card on a lanyard. It appears blank, yet also appears to show a variety of credentials at the same time."
     do npc says demerzel "Here is your visitor pass. Much of the facility will be inaccessible without it, so treat it like a second towel."
 }

--- a/amble_script/data/Amble/areas/bldg_main_floor/puzzles/get_elevator_keycard.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/puzzles/get_elevator_keycard.amble
@@ -47,11 +47,9 @@ item poetry_performer {
 # Triggers
 # ========================================
 
-
-
 trigger "[Poetry-Panic] Acquired Elevator Keycard" only once
 when take elevator_keycard {
-    do set npc state demerzel bored
+    do set npc state demerzel custom:impressed
     do add flag got-elevator-keycard
     do modify item aa_3_button_main {
         name "[AA-3] Button"

--- a/amble_script/data/Amble/areas/bldg_main_floor/puzzles/get_invitation.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/puzzles/get_invitation.amble
@@ -4,6 +4,7 @@
 
 item charred_invitation_bits {
     name "Charred Paper Bits"
+    visible when missing flag status:flash-blind
     desc "The charred remains of a sheet of printer paper. A few areas aren't completely black, or vaporized. One bit remains legible."
     movability free
     location nowhere "spawns@aperture-lab"
@@ -22,6 +23,7 @@ item asbestos_sheet {
 
 item invitation {
     name "Engraved Invitation"
+    visible when missing flag status:flash-blind
     desc "A standard letter-size slab of asbestos with ornate and official-looking lettering burned into it. It remains too hot to touch."
     movability free
     location nowhere "spawns@aperture-lab"
@@ -31,34 +33,40 @@ You are cordially invited to complete your evaluation and induction. Please pres
     requires insulate to handle
 }
 
+item purple_vision_blob {
+    name "Scintillating Purple Blob"
+    visible when has flag status:flash-blind
+    desc "A pretty violet blob flashed into your central vision by the PlasmaJet printer."
+    location room aperture-lab
+    movability fixed "It's an optical illusion. Hopefully temporary."
+}
+
 # ========================================
-# Triggers
+# PLASMAJET PRINTER TRIGGERS / DEFINITIONS
 # ========================================
 
-trigger "[Aperture-Lab] Printer Loaded"
+trigger "[Aperture-Lab] Printer Loaded (paper)"
 note "change printer display when paper inserted"
 when insert item printer_paper into item lab_printer {
     if has flag got-invitation {
         do modify item lab_printer {
             text "0 JOB(S) PENDING"
         }
-    }
-    if missing flag got-invitation {
+    } else {
         do modify item lab_printer {
             text "1 JOB(S) PENDING"
         }
     }
 }
 
-trigger "[Aperture-Lab] Printer Loaded"
+trigger "[Aperture-Lab] Printer Loaded (asbestos)"
 note "change printer display when asbestos sheet inserted"
 when insert item asbestos_sheet into item lab_printer {
     if has flag got-invitation {
         do modify item lab_printer {
             text "0 JOB(S) PENDING"
         }
-    }
-    if missing flag got-invitation {
+    } else {
         do modify item lab_printer {
             text "1 JOB(S) PENDING"
         }
@@ -73,36 +81,66 @@ when use item lab_printer ability turnOn {
     }
 }
 
-trigger "[Aperture-Lab] Printer Burns Paper"
+trigger "[Aperture-Lab] PlasmaJet Used"
 when use item lab_printer ability turnOn {
     if container lab_printer has item printer_paper {
-        do despawn item printer_paper
-        do add flag burned-invitation
-        do spawn item flaming_invitation into room aperture-lab
-        do schedule in 5 note "invitation finishes burning" {
-            do replace item flaming_invitation with charred_invitation_bits
-        }
-        do add wedge "An annoyed voice on the PA: ATTENTION Staff - do NOT use regular copy paper in the lab PlasmaJet printer, or we will be shut down again -- by order of FEMA, PETA, the ATF, FBI, and our HOA." width 1 spinner ambientInterior
-        do show "The paper ignites in a flash, and the PlasmaJet spits a flaming document on the floor at your feet."
-        do schedule in 2 {
-            do show "A nearby smoke detector alarms briefly, the quits with an exasperated sigh when it sees you near the PlasmaJet printer, figuring you get what you deserve."
-        }
+        run PRINTER_USED_WITH_PAPER
+    } else if container lab_printer has item asbestos_sheet {
+        run PRINTER_USED_WITH_ASBESTOS
+    } else {
+        do show "The printer just clicks once. You may want to check the status screen or the paper tray."
     }
 }
 
-trigger "[Aperture-Lab] Print Invitation on Asbestos" only once
-when use item lab_printer ability turnOn {
-    if container lab_printer has item asbestos_sheet {
-        do add flag invitation-sans-ignition
-        do award points 10 reason "Printed the invitation on asbestos stock"
-        do despawn item asbestos_sheet
-        do show "The PlasmaJet emits a blinding flash of light, leaving a printer-shaped purple blob in your visual field and blinding you for a few moments."
-        do schedule in 2 note "blindness clears" {
-            do spawn item invitation into room aperture-lab
-            do show "Your vision begins to clear, and you see an engraved invitation on the floor. It glows slightly, and waves of heat warp the air around it."
-        }
+let actions PRINTER_USED_WITH_PAPER = {
+    do show "The paper ignites in an instant, and the PlasmaJet spits a flaming document on the floor at your feet."
+    do add flag burned-invitation
+    do despawn item printer_paper
+    do spawn item flaming_invitation into room aperture-lab
+    do schedule in 5 note "invitation finishes burning" {
+        do show "The flaming invitation goes fizzles out, leaving behind a few charred remains."
+        do replace item flaming_invitation with charred_invitation_bits
+    }
+
+    do add wedge "An annoyed voice on the PA: ATTENTION Staff - do NOT use regular copy paper in the lab PlasmaJet printer, or we will be shut down again -- by order of FEMA, PETA, the ATF, FBI, and our HOA." width 1 spinner ambientInterior
+    do schedule in 2 note "desensitized smoke detector" {
+        do show "A nearby smoke detector alarms briefly, the quits with an exasperated sigh when it sees you near the PlasmaJet printer, figuring you get what you deserve."
     }
 }
+
+let actions PRINTER_USED_WITH_ASBESTOS = {
+    do add flag invitation-sans-ignition
+    do award points 10 reason "Printed the invitation on asbestos stock"
+    do despawn item asbestos_sheet
+    do spawn item invitation into room aperture-lab
+    run FLASH_BLINDNESS
+}
+
+let actions FLASH_BLINDNESS = {
+    do add flag status:flash-blind
+    do show "The PlasmaJet emits a blinding flash of light, leaving a printer-shaped purple blob in your visual field and blinding you for a few moments."
+    do modify room aperture-lab {
+        name "Purple Blob Lab"
+        desc "It still feels like you're in the lab, but all you can see is a fading purple blob in your central vision."
+        remove exit portal-room
+        remove exit stargate-room
+    }
+    do schedule in 3 note "flash blindness clears" {
+        do show "Your vision begins to clear, and you see an invitation on the floor, burned into the asbestos sheet. It glows slightly, and waves of heat warp the air around it."
+        do remove flag status:flash-blind
+        do modify room aperture-lab {
+            name "Aperture Laboratory"
+            desc "The walls, floor, ceiling, and even the air here feels clinical and overexposed. Everything hums at a frequency designed to encourage strict compliance. A few [[bright-red]]fire extinguishers[[/bright-red]] are scattered about. A very dated computer console glows green on a table beside a [[i]]highly[[/i]] over-engineered printer labeled [[hl]][[b]]Aperture|Amble Hospitality Generator[[/b]][[/hl]]. Across the room, a [[item]]vault-like door[[/item]] all but [[i]]demands[[/i]] attention."
+            add exit "through the portal" -> portal-room
+            add exit "into the vault" -> stargate-room
+        }
+    }
+
+}
+
+# ========================================
+# INVITATION INSULATION TRIGGERS
+# ========================================
 
 trigger "[Aperture-Lab] Insulate With Towel"
 when use item towel on item invitation interaction handle {

--- a/amble_script/data/Amble/areas/bldg_main_floor/puzzles/open_a_portal.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/puzzles/open_a_portal.amble
@@ -29,12 +29,12 @@ item empty_battery {
 trigger "[Gonk Droid] Battery Exchange" only once
 note "necessary step in portal gun puzzle"
 when give item empty_battery to npc gonk_droid {
+    do show "Elated that you've given it such a large, empty battery to charge, the gonk droid gives you a fully charged one, free of ... charge?"
     do award points 2 reason "Swapped the drained battery with the helpful gonk droid"
     do set item movability empty_battery restricted "You can't take it back. The gonk droid is still charging it and won't let it go."
     do give item charged_battery to player from npc gonk_droid
     do add flag got-charged-battery
     do set npc state gonk_droid happy
-    do show "Elated that you've given it such a large, empty battery to charge, the gonk droid gives you a fully charged one, free of ... charge?"
 }
 
 trigger "[Portal-Room] Gun Opened" only once
@@ -45,26 +45,23 @@ when open item portal_gun {
 
 trigger "[Portal-Room] Gun Powered"
 when insert item charged_battery into item portal_gun {
+    do show "Arcing wildly as you insert it, the fully charged 20 KV battery fuses itself to the contacts inside the portal gun -- when then emits a quick high-pitched whine. The POWER indicator lights a steady green."
     do add flag portal-gun-powered
     do award points 3 reason "Powered up the portal gun"
     do set item movability charged_battery fixed "When it was inserted, the arcing electricity welded it to the contacts."
     do set item description portal_gun "A black and white Portal gun sits bolted to its pedestal, aimed at a target on the wall. A fused battery juts from the compartment and the power indicator glows steadily green."
-    do show "Arcing wildly as you insert it, the fully charged 20 KV battery fuses itself to the contacts inside the portal gun -- when then emits a quick high-pitched whine. The POWER indicator lights a steady green."
 }
 
-trigger "[Portal-Room] Gun Fired / Open Portal" only once
+trigger "[Portal-Room] Gun Fired / Open Portal"
 when use item portal_gun ability turnOn {
-    if has flag portal-gun-powered {
+    if has flag portal-opened {
+        do show "The gun emits a low [[hl]]brop[[/hl] sound and the portal changes shape, but the view to the laboratory on the other side remains the same."
+    } else if has flag portal-gun-powered {
+        do show "A loud SQUIP! comes from the gun when you turn it on. The wall in front of it sizzles for a moment, and then a crackling oval blue portal expands there to reveal a laboratory space on the other side."
         do reveal exit from portal-room to aperture-lab direction "through the portal"
         do add flag portal-opened
         do award points 5 reason "Opened a portal into Aperture Labs"
-        do show "A loud SQUIP! comes from the gun when you turn it on. The wall in front of it sizzles for a moment, and then a crackling oval blue portal expands there to reveal a laboratory space on the other side."
-    }
-}
-
-trigger "[Portal-Room] Tried Gun Without Power"
-when use item portal_gun ability turnOn {
-    if missing flag portal-gun-powered {
+    } else {
         do show "You attempt to turn the portal gun on, but the POWER light briefly flashes red, then goes dark. Nothing else happens."
     }
 }

--- a/amble_script/data/Amble/areas/bldg_main_floor/rooms/antechamber.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/rooms/antechamber.amble
@@ -2,6 +2,72 @@
 
 room antechamber {
     name "Antechamber"
-    desc "<TODO> Fun description of antechamber leading to two doors, one for each sect."
+    desc """A circular waiting room lies beyond the Stargate, laid out with the solemn grandeur of a temple and the administrative cheer of a municipal licensing office. The floor is an intricate mosaic of sandals, vines, halos and what may simply be decorative punctuation. Two nearly identical doors stand opposite the gate, each trying very hard to look like the only reasonable choice a civilized soul could make. Between them, a brass [[item]]Directory Plaque[[/item]] and an overstuffed [[item]]Suggestion Box[[/item]] quietly imply that sectarian certainty requires a surprising amount of paperwork."""
+
+    overlay if flag set sect-shoe {
+        text "The sandal-marked door seems calm, welcoming, and faintly superior. The gourd-marked door somehow manages to look judgmental despite being a vegetable-themed door."
+    }
+
+    overlay if flag set sect-gourd {
+        text "The gourd-marked door radiates a mellow autumnal confidence. The sandal-marked door has the air of something that would correct your posture while condemning your soul."
+    }
+
     exit "through the stargate" -> stargate-room
+    exit "through the sandal-marked door" -> shoe-shrine {
+        required_flags( sect-shoe ),
+        barred "The sandal-marked door refuses to admit you. A tiny brass voice grille politely explains that access is restricted to the properly shod in spirit."
+    }
+    exit "through the gourd-marked door" -> gourd-shrine {
+        required_flags( sect-gourd ),
+        barred "The gourd-marked door remains shut. Somewhere within the woodwork, a mellow but disapproving silence suggests you lack sufficient cucurbit conviction."
+    }
+
+    scenery "Mosaic Floor" desc "Thousands of tiny tiles depict worshippers arguing over footwear, produce, and the exact angle at which enlightenment ought to be shelved."
+    scenery "Twin Doors" desc "One bears a carved sandal haloed in gold leaf; the other bears a plump gourd wreathed in vines. Each has the smug air of a doctrine that has won an argument with itself."
+    scenery "Ceiling Dome" desc "The painted dome above shows a starry sky in which several constellations have been suspiciously redrawn to resemble either a sandal or a gourd, depending on where you stand and how willing you are to be persuaded."
+    scenery "Benches" desc "Two padded benches line the wall beneath framed notices about reverence, queueing, and the inadvisability of starting comparative theology before lunch."
+}
+
+item sect_directory_plaque {
+    name "Directory Plaque"
+    aliases "plaque", "directory"
+    desc "A polished brass plaque mounted between the two inner doors."
+    movability fixed "It is bolted to the wall with ecumenical firmness."
+    visibility scenery
+    location room antechamber
+    ability Read
+    text """[[box:WAYFINDING FOR THE DEVOUT]]
+Left of Certainty ........ Shrine of the Holy Shoe
+Right of Certainty ....... Shrine of the Holy Gourd
+Straight Back ............ Stargate / Unscheduled Transcendence
+
+[[center]][[i]]Please keep doctrinal disputes below a resonant chanting level.[[/i]][[/center]]"""
+}
+
+item schism_suggestion_box {
+    name "Suggestion Box"
+    aliases "box"
+    desc "An oak suggestion box with two slots labeled [[i]]Constructive Feedback[[/i]] and [[i]]Vindictive Denunciation[[/i]]. The second slot is much more worn."
+    movability fixed "It is chained to a pedestal, presumably after an incident."
+    visibility scenery
+    location room antechamber
+    ability Read
+    text """[[box:SUGGESTION BOX GUIDELINES]]
+1. Keep notes brief, legible, and only moderately anathematizing.
+2. Do not submit produce.
+3. Do not submit footwear.
+4. Do not submit produce about footwear.
+5. Complaints concerning the nonbeliever observation room will be accepted once reality catches up."""
+}
+
+trigger "[Antechamber] First Arrival" only once
+when enter room antechamber {
+    do show "The room greets you with the hushed tension of a place in which people have spent centuries being polite at each other as hard as they can."
+    do schedule in 2 if player in room antechamber onFalse cancel {
+        if has flag sect-shoe {
+            do show "From somewhere beyond the gourd-marked door comes a muffled chant whose general theme appears to be that vegetables were a mistake."
+        } else if has flag sect-gourd {
+            do show "From somewhere beyond the sandal-marked door comes a clipped chorus suggesting that produce has no business in serious metaphysics."
+        }
+    }
 }

--- a/amble_script/data/Amble/areas/bldg_main_floor/rooms/antechamber.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/rooms/antechamber.amble
@@ -1,0 +1,7 @@
+# Antechamber to the Sect Shrines
+
+room antechamber {
+    name "Antechamber"
+    desc "<TODO> Fun description of antechamber leading to two doors, one for each sect."
+    exit "through the stargate" -> stargate-room
+}

--- a/amble_script/data/Amble/areas/bldg_main_floor/rooms/aperture_lab.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/rooms/aperture_lab.amble
@@ -7,10 +7,14 @@ room aperture-lab {
     desc "The unnaturally white walls, floor, ceiling, even the air here feels clinical and overexposed. Everything hums at a frequency designed to encourage strict compliance. A few [[bright-red]]fire extinguishers[[/bright-red]] are scattered about, though there isn't any obvious source of ignition around. A very dated computer console glows green on a table beside a [[i]]highly[[/i]] over-engineered printer labeled [[hl]][[b]]Aperture|Amble Hospitality Generator[[/b]][[/hl]]. Across the room, a [[item]]vault-like door[[/item]] all but [[i]]demands[[/i]] attention."
 
     scenery default "The {thing} [[i]][[u]]seems[[/u]][[/i]] normal, but here in [[room]]Aperture Laboratories[[/room]]? I wouldn't trust it."
+
     scenery "Walls" desc "The unnatural thing about these white walls is that they emit light, but sharp shadows can still be cast on them... which allows you to see that your shadow seems to merely [[i]]approximate[[/i]] your movements, and with a barely perceptible delay."
+
     scenery "Lab Floor"
+
     scenery "Ceiling" desc "A typical industrial ceiling with barely hidden conduits and pipes for fire (or riot) suppression systems overhead."
     scenery "Table"
+
     scenery "Your Shadow" desc "[[b]][[i]]It looks back at you.[[/i]][[/b]]"
 
     overlay if ( flag set burned-invitation, flag unset invitation-sans-ignition ) {
@@ -25,7 +29,7 @@ room aperture-lab {
     overlay if ( flag set invitation-sans-ignition ) {
         text "The printer is in its 3-day cooldown period, and there are no jobs pending."
     }
-    overlay if ( item present invitation ) {
+    overlay if ( item present invitation, flag unset status:flash-blind ) {
         text "A glowing, steaming, sizzling invitation engraved on an asbestos sheet sits on the floor in front of the printer."
     }
 
@@ -38,6 +42,7 @@ room aperture-lab {
 # ========================================
 item apple_lab_pc {
     visibility scenery
+    visible when missing flag status:flash-blind
     name "Apple ][+"
     aliases "pc", "console", "computer", "apple"
     desc "An ancient, 8-bit Apple ][+ computer complete with monochrome CRT character display, and inexplicably hard-wired into the [[i]]bleeding edge[[/i]] plasma-jet printer nearby."
@@ -62,6 +67,7 @@ item lab_vault_door {
 
 item magnifying_glass {
     name "Magnifying Glass"
+    visible when missing flag status:flash-blind
     desc "Small gets big -- it's a rig."
     movability free
     location room aperture-lab
@@ -70,6 +76,7 @@ item magnifying_glass {
 
 item lab_printer {
     name "Initech PlasmaJet 2 Printer"
+    visible when missing flag status:flash-blind
     aliases "status", "screen", "hospitality generator"
     desc "A sleek, off white printer, with a blinking LED near a small status screen. This model is known for its high precision, micrometer-level resolution, and ability to ignite almost any printing surface."
     movability fixed "It is mounted to the lab bench."

--- a/amble_script/data/Amble/areas/bldg_main_floor/rooms/b_a_office.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/rooms/b_a_office.amble
@@ -97,7 +97,11 @@ when open item poetry_performer {
 
 trigger "[Office] Gifted Lost and Found Key" only once
 when enter room amble-office {
-    if all( has flag got-elevator-keycard, with npc demerzel ) {
+    if all(
+        has flag got-elevator-keycard,
+        with npc demerzel,
+        npc has item demerzel lost_and_found_key,
+    ) {
         do give item lost_and_found_key to player from npc demerzel
         do priority -40 show "Seeing you return with the keycard, the receptionist looks around warily and slips something into your hand, then looks directly at the lost and found box."
         do priority -50 npc says demerzel "Finally! A Candidate bright enough to get to that keycard. I lost the pool. Who would have thought it would be a primate?"
@@ -130,4 +134,12 @@ goal get-visitor-pass {
     group required
     start when goal complete get-invited
     done when has flag got-visitor-pass
+}
+
+goal access-lost-and-found {
+    name "Gain Access to Lost and Found"
+    desc "There is a Lost and Found box in the office, and Demerzel has the key. When she's impressed enough with your progress, she'll give it to you."
+    group required
+    start when reached room amble-office
+    done when has flag lost-and-found-opened
 }

--- a/amble_script/data/Amble/areas/bldg_main_floor/rooms/gourd-shrine.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/rooms/gourd-shrine.amble
@@ -1,6 +1,6 @@
 room gourd-shrine {
     name "Shrine of the Holy Gourd"
-    desc """This chapel glows with warm amber light filtered through bottle-green glass, giving everything the reverent complexion of very expensive soup. Vines curl around fluted pillars, seed motifs repeat across the floor, and at the far end a circular [[item]]Harvest Altar[[/item]] stands beneath a domed canopy. A velvet-lined recess at its center is being guarded by atmosphere alone, which in this room seems to consider itself armed. The air smells of beeswax, autumn leaves, and the smug serenity of people who believe a vegetable solved the major philosophical questions decades ago."""
+    desc """This chapel glows with warm amber light filtered through bottle-green glass, giving everything the reverent complexion of very expensive soup. Vines curl around fluted pillars, seed motifs repeat across the floor, and at the far end a circular [[item]]Harvest Altar[[/item]] stands beneath a domed canopy. A velvet-lined recess at its center is being guarded by atmosphere alone, which in this room seems to consider itself armed. The air smells of beeswax, autumn leaves, and the smug serenity of people who believe a vegetable solved the major philosophical questions decades ago. Near the entry, a [[item]]hymn board[[//item]] spells out the plan for the day's worship while an [[item]]abacus[[/item]] stands ready to count the devoted."""
 
     exit "leave the shrine" -> antechamber
 

--- a/amble_script/data/Amble/areas/bldg_main_floor/rooms/gourd-shrine.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/rooms/gourd-shrine.amble
@@ -1,0 +1,64 @@
+room gourd-shrine {
+    name "Shrine of the Holy Gourd"
+    desc """This chapel glows with warm amber light filtered through bottle-green glass, giving everything the reverent complexion of very expensive soup. Vines curl around fluted pillars, seed motifs repeat across the floor, and at the far end a circular [[item]]Harvest Altar[[/item]] stands beneath a domed canopy. A velvet-lined recess at its center is being guarded by atmosphere alone, which in this room seems to consider itself armed. The air smells of beeswax, autumn leaves, and the smug serenity of people who believe a vegetable solved the major philosophical questions decades ago."""
+
+    exit "leave the shrine" -> antechamber
+
+    scenery "Stained Glass" desc "Panels of heroic gourds float among stars, feed the multitudes, and in one especially ambitious scene appear to invent both ethics and seasonal decor."
+    scenery "Seed Mosaics" desc "Tiny polished seeds have been pressed into the floor in elaborate spirals. They form sacred symbols, or possibly a diagram explaining how to make a very complicated tart."
+    scenery "Pews" desc "Low benches arc toward the altar in a gentle crescent. Each kneeler is stuffed with something pleasantly springy that you suspect is either moss or doctrine."
+    scenery "Vines" desc "Decorative vines wind up the pillars in careful symmetry. They are either carved wood or very disciplined plants."
+}
+
+item gourd_hymn_board {
+    name "Hymn Board"
+    aliases "board", "hymn board"
+    desc "A carved wooden board displays the order of service in tidy movable letters."
+    movability fixed "It is mounted securely to the wall."
+    visibility scenery
+    location room gourd-shrine
+    ability Read
+    text """[[box:ORDER OF MELLOW EXULTATION]]
+Opening Chant ............ O Round and Plentiful One
+Responsive Reading ....... Seeds of Wisdom, Verses 4-12
+Meditation ............... On the Folly of Single Sandals
+Closing Hymn ............. Abide With Gourd
+
+[[center]][[i]]Latecomers may join in at whatever verse feels spiritually seasonal.[[/i]][[/center]]"""
+}
+
+item harvest_altar {
+    name "Harvest Altar"
+    aliases "altar"
+    desc "A circular altar of polished wood and green stone. Its center holds a velvet-lined niche clearly reserved for an Object of Great Significance, or at least an Object prepared to put up with a great deal of incense."
+    movability fixed "It appears to weigh slightly more than piety."
+    visibility scenery
+    location room gourd-shrine
+}
+
+item seed_abacus {
+    name "Seed Abacus"
+    aliases "abacus"
+    desc "A brass frame strung with lacquered seeds. It seems to be used for counting prayers, blessings, or casserole attendees."
+    movability fixed "It is attached to a stand that looks rooted in theology."
+    visibility scenery
+    location room gourd-shrine
+}
+
+trigger "[Gourd-Shrine] First Visit" only once
+when enter room gourd-shrine {
+    do show "A tranquil hush settles around you. It is the sort of hush that fully expects applause for being tranquil."
+    do schedule in 2 if player in room gourd-shrine onFalse cancel {
+        do show "A hidden choir hums a note so warm and rounded it feels less heard than gently ladled."
+    }
+}
+
+trigger "[Gourd-Shrine] Touch Altar"
+when touch item harvest_altar {
+    do show "The polished surface is warm to the touch. Either candles burn nearby, or devotion here has been left simmering."
+}
+
+trigger "[Gourd-Shrine] Touch Abacus"
+when touch item seed_abacus {
+    do show "Several seeds click across the rods and settle on a number that feels meaningful, though it may simply indicate soup."
+}

--- a/amble_script/data/Amble/areas/bldg_main_floor/rooms/lounge.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/rooms/lounge.amble
@@ -6,9 +6,9 @@ room lounge {
     scenery "Magazines" desc "Editions include a [[i]]Highlights[[/i]] magazine with all of the puzzles completed (incorrectly) and a [[i]]National Geographic[[/i]] from 1983."
     scenery "Jigsaw Puzzle" desc "Partially assembled, it the [[item]]jigsaw puzzle[[/item]] appears to be a depiction of a Borg cube."
 
-    overlay if item lebowski_rug {
-        present "An ornate, brick red rug lies in the center of the room and somehow -- really ties the room together."
-        absent "The trap door opened in the floor reveals a ladder down to a hidden room below."
+    overlay if flag found-portal-room {
+        set "With the rug out of the way, the trap door found underneath opens to reveal a ladder down to a [[room]]hidden room[[/room]] below."
+        unset "An ornate, brick red [[item]]rug[[/item]] lies in the center of the room and somehow -- really ties the room together, man."
     }
 
     overlay if flag set lab-fire-raging {
@@ -51,6 +51,8 @@ item lebowski_rug {
     movability free
     location room lounge
     requires ignite to burn
+    ability Read
+    text "[[box]]Property of Maude Lebowski[[/box]]"
 }
 
 item coffee_machine {
@@ -96,7 +98,7 @@ item cooled_coffee {
 
 trigger "Coffee Cools Down" only once
 when take hot_coffee {
-    do schedule in 7 note "coffee cooled" {
+    do schedule in 10 note "coffee cooled" {
         do replace item hot_coffee with cooled_coffee
     }
 }

--- a/amble_script/data/Amble/areas/bldg_main_floor/rooms/main_lobby.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/rooms/main_lobby.amble
@@ -4,11 +4,11 @@
 
 room main-lobby {
     name "Main Lobby"
-    desc "The lobby is clinically clean in a way that feels suspicious. A slightly humming vending machine stands beside an empty podium. Softly glowing script over an archway on the far wall reads 'Elevator Access'. To one side, there is floor-to-ceiling frosted glass with an etched door at the farthest end from the entrance. Opposite that, the smell of searing beef wafts from a broad entryway flanked by a wobbly sign."
+    desc "The lobby is clinically clean in a way that feels suspicious. A slightly humming vending machine stands beside an empty podium. Softly glowing script over an archway on the far wall reads [[i]][[blue]]Lift Access[[/blue]][[/i]] where a few short steps lead up to an elevator bank. To one side, there is floor-to-ceiling frosted glass with an etched door at the farthest end from the entrance. Opposite that, the smell of searing beef wafts from a broad entryway flanked by a wobbly sign."
 
     scenery "Empty Podium" desc "A typical wooden podium used to welcome incoming visitors, and just as typically vacant. It bears an emblem that reads: [[hl]][[i]]Welcome, Candidate[[/i][[/hl]]."
 
-    scenery "Etched Door" desc "A frosted glass office door, etched with: [[box:MAIN OFFICE]]Amble Adventures[[/box]]"
+    scenery "Frosted Glass Door" desc "A frosted glass office door, etched with: [[box:MAIN OFFICE]]Amble Adventures[[/box]]"
 
     overlay if npc gonk_droid here {
         normal "A gonk droid stands idle in the corner, muttering to itself and tottering in circles."
@@ -19,10 +19,10 @@ room main-lobby {
         happy  "Dibbler grins broadly, offering a complimentary bite."
         bored  "Dibbler mutters about slow lobby sales."
     }
-    exit "elevator access" -> lift-bank-main
+    exit "lift access" -> lift-bank-main
     exit "outside" -> front-entrance
     exit "broad entryway" -> restaurant
-    exit "etched door" -> amble-office
+    exit "frosted glass door" -> amble-office
 }
 
 item restaurant_sign {
@@ -194,11 +194,15 @@ spinner fortunes {
 trigger "[Main-Lobby] Security Reminder" only once
 when enter room main-lobby
 {
-    do show """A chime echoes through the lobby. "Candidates: Please do not loiter in the lobby," intones an overhead voice."""
-    do schedule in 3 if player in room main-lobby onFalse cancel
-    note "lobby loitering reminder" {
-        do show """The chime sounds again. "Candidates: We **said** not to loiter in the lobby," says the voice, in more of an annoyed tone."""
-        do award points -1 reason "Ignored the lobby loitering reminder"
+    do schedule in 2 note "lobby loitering warning"
+    {
+        do show """A chime echoes through the lobby. "Candidates: Please do not loiter in the lobby," intones an overhead voice."""
+
+        do schedule in 5 if player in room main-lobby onFalse cancel
+        note "lobby loitering penalty" {
+            do show """The chime sounds again. "Candidates: We **said** not to loiter in the lobby," says the voice, in more of an annoyed tone."""
+            do award points -1 reason "Ignored the lobby loitering warning"
+        }
     }
 }
 
@@ -221,5 +225,5 @@ when use item fishing_line on item zircon_tweezers_crevice interaction handle
     do despawn item zircon_tweezers_crevice
     do spawn item zircon_tweezers in inventory
     do add flag recovered-tweezers
-    do award points 3 reason "Fished the zircon tweezers out of the vending machine"
+    do award points 3 reason "Fished the zircon tweezers out of the vending machine crevice"
 }

--- a/amble_script/data/Amble/areas/bldg_main_floor/rooms/patio.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/rooms/patio.amble
@@ -83,9 +83,10 @@ when use item plaque_3 ability read {
     do add flag read-plaque-3
     do award points 10 reason "Reached and read the third crystal plaque"
     if has visited room stargate-room {
-        # close other gates and open this one
         do show "(A new Stargate destination has been enabled.)"
-        run connect_patio_stargate
+        run CONNECT_PATIO_STARGATE
+    } else {
+        do show "(Somewhere, something connected has been enabled.)"
     }
 }
 

--- a/amble_script/data/Amble/areas/bldg_main_floor/rooms/shoe_shrine.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/rooms/shoe_shrine.amble
@@ -1,0 +1,66 @@
+room shoe-shrine {
+    name "Shrine of the Holy Shoe"
+    desc """A long, narrow chapel of polished oak and stern symmetry stretches before you, lit by stained glass windows that cast sandal-shaped colors across the floor. A [[item]]liturgy board[[/item]] announces the day's plan near the entryway, with the obligatory [[item]]donation box[[/item]] mounted below it. At the far end, on a raised [[item]]Sandal Altar[[/item]], a velvet-lined recess sits at attention beneath a cone of buttery light. Rows of pews face forward with the crisp obedience of well-behaved feet. The air carries beeswax, old leather, and the faint, intoxicating scent of absolute certainty rubbed to a shine."""
+
+    exit "leave the shrine" -> antechamber
+
+    scenery "Stained Glass" desc "The windows depict the Sacred Sandal performing small but decisive miracles: crossing deserts, toppling heretics, and in one panel apparently inventing the idea of [[b]]left[[/b]] and [[b]]right[[/b]]."
+    scenery "Pews" desc "Straight-backed pews stand in impeccable rows. The kneelers are shaped with orthopedic conviction."
+    scenery "Polished Floor" desc "The boards gleam so brightly you can see your reflection looking slightly more devout than usual."
+    scenery "Censers" desc "Brass censers hang from the rafters, swinging very slightly and releasing a fragrance halfway between incense and a cobbler's workshop."
+}
+
+item shoe_liturgy_board {
+    name "Liturgy Board"
+    aliases "board", "liturgy board", "hymn board"
+    desc "A mahogany board lists the day's readings and hymns in severe gold letters."
+    movability fixed "It is affixed with screws that look doctrinally approved."
+    visibility scenery
+    location room shoe-shrine
+    ability Read
+    text """[[box:ORDER OF SOLEMN OBSERVANCE]]
+Opening Processional ..... Tread Lightly, Yet With Conviction
+Reading .................. The Book of Arch Support, Chapter 3
+Homily ................... On the Error of Overvaluing Produce
+Closing Hymn ............. Guide Me, O Thou Great Sandal
+
+[[center]][[i]]Please keep both feet pointed toward the altar during moments of revelation.[[/i]][[/center]]"""
+}
+
+item sandal_altar {
+    name "Sandal Altar"
+    aliases "altar"
+    desc "A lacquered wooden altar trimmed in brass. At its center rests a velvet-lined recess shaped for an article of singular sacred importance, patiently awaiting either revelation or a careful dusting."
+    movability fixed "It is solid, immovable, and plainly in favor of arch support."
+    visibility scenery
+    location room shoe-shrine
+}
+
+item heel_the_poor_fund {
+    name "Heel the Poor Fund"
+    aliases "donation box", "fund"
+    desc "A brass donation box polished to missionary brightness. The slot is worn smooth by generations of charitable guilt."
+    movability fixed "It is locked, weighted, and probably insured."
+    visibility scenery
+    location room shoe-shrine
+    ability Read
+    text "[[box]]HEEL THE POOR[[/box]][[center]][[i]]Loose change gladly accepted. Tight change accepted with gentle disappointment.[[/i]][[/center]]"
+}
+
+trigger "[Shoe-Shrine] First Visit" only once
+when enter room shoe-shrine {
+    do show "A discreet bell chimes somewhere overhead, as if noting your arrival in a ledger maintained by very tidy angels."
+    do schedule in 2 if player in room shoe-shrine onFalse cancel {
+        do show "From the rafters comes a whisper: \"If the Shoe fits...\" followed by several devout voices murmuring, \"...mind the laces of destiny.\""
+    }
+}
+
+trigger "[Shoe-Shrine] Touch Altar"
+when touch item sandal_altar {
+    do show "The wood is mirror-smooth and faintly warm. The shrine's caretakers either polish constantly or have achieved a workable theology of wax."
+}
+
+trigger "[Shoe-Shrine] Touch Donation Box"
+when touch item heel_the_poor_fund {
+    do show "The box gives off the dense metallic clink of accumulated virtue."
+}

--- a/amble_script/data/Amble/areas/bldg_main_floor/rooms/stargate_room.amble
+++ b/amble_script/data/Amble/areas/bldg_main_floor/rooms/stargate_room.amble
@@ -25,9 +25,54 @@ room stargate-room {
         set   "On the right, shaped like a fork:       [[green]]RAISED[[/green]]"
         unset "On the right, shaped like a fork:       [[red]][[dimmed]]sunken[[/dimmed]][[/red]]"
     }
+
+    overlay if flag set sect-gourd {
+        text  "Underneath, shaped like a fish:         [[green]]RAISED[[/green]]"
+    }
+    overlay if flag set sect-shoe {
+        text  "Underneath, shaped like a fish:         [[green]]RAISED[[/green]]"
+    }
+    overlay if flag unset sect-gourd, flag unset sect-shoe {
+        text  "Underneath, shaped like a fish:         [[red]][[dimmed]]sunken[[/dimmed]][[/red]]"
+    }
+
     exit "vault door" -> aperture-lab
 }
 
+# ========================================
+# Activate Sect Gate
+# ========================================
+
+item sect_gate_button {
+    name "[ Fish ]"
+    desc "A stylized, fish-shaped icon adorns this button. It's a little smaller than the other buttons, placed quietly out of the way, and seems almost like the designer of the Stargate control didn't want to include it at all."
+    movability fixed "It's part of the Stargate control console."
+    location room stargate-room
+}
+
+trigger "[Stargate] Sect Gate: Activate" only once
+note "schedule/give point award for first time opening gate"
+when touch item sect_gate_button {
+    do schedule in 1 if joined_any_sect onFalse retryNextTurn {
+        do award points 5 reason "Activated the Sectarian Gate"
+        do add flag sect-gate-enabled
+    }
+}
+
+trigger "[Stargate] Press Woodland Button"
+note "open/move the Stargate connection to the Sect Antechamber (only if a member)"
+when touch item sect_gate_button {
+    if all( joined_any_sect, missing flag sect-gate-open ) {
+        do show "With a great whooshing like the flush of a titan's toilet, the Stargate opens a new connection. Angelic sounds float through the gate, oddly paired with the smell of leather and pumpkins."
+        run CONNECT_SECT_STARGATE
+    }
+    if all( joined_any_sect, has flag sect-gate-open ) {
+        do show "The gate to the antechamber is already open."
+    }
+    if no_sect_joined {
+        do show "The fish button is already pressed down as far as it can go; you can't activate it."
+    }
+}
 # ========================================
 # Activate Woodland Gate
 # ========================================
@@ -56,14 +101,12 @@ when touch item woodland_button {
     }
 }
 
-
-
 trigger "[Stargate] Press Woodland Button"
 note "open/move the Stargate connection to Parish Landing (only if plaque-1 read)"
 when touch item woodland_button {
     if all( has flag read-plaque-1, missing flag woodland-gate-open ) {
         do show "With a great whooshing like the flush of a titan's toilet, the Stargate opens a new connection. You hear singing birds and the occasional screech coming through the opening."
-        run connect_woodland_stargate
+        run CONNECT_WOODLAND_STARGATE
     }
     if all( has flag read-plaque-1, has flag woodland-gate-open ) {
         do show "The gate to the woodlands is already open."
@@ -93,14 +136,12 @@ when touch item snowfield_button {
     }
 }
 
-
-
 trigger "[Stargate] Press Snowfield Button"
 note "open/move the Stargate connection to Ice Pit (only if plaque 2 read)"
 when touch item snowfield_button {
     if all( has flag read-plaque-2, missing flag snowfield-gate-open ) {
         do show "With a great whooshing like the flush of a titan's toilet, the Stargate opens a new connection. Suddenly, you can see your breath -- condensed by the frigid air pouring through the opening."
-        run connect_snowfield_stargate
+        run CONNECT_SNOWFIELD_STARGATE
     }
     if all( has flag read-plaque-2, has flag snowfield-gate-open ) {
         do show "The gate to the snowfield is already open."
@@ -130,14 +171,12 @@ when touch item patio_button {
     }
 }
 
-
-
 trigger "[Stargate] Press Patio Button"
 note "open/move the Stargate connection to the Patio (only if plaque-3 read)"
 when touch item patio_button {
     if all( has flag read-plaque-3, missing flag patio-gate-open ) {
         do show "With a great whooshing like the flush of a titan's toilet, the Stargate opens a new connection. The smells of fresh baked bread and searing beef waft  through the opening."
-        run connect_patio_stargate
+        run CONNECT_PATIO_STARGATE
     }
     if all( has flag read-plaque-3, has flag patio-gate-open ) {
         do show "The gate to the restaurant patio is already open."
@@ -162,49 +201,80 @@ when touch item patio_button {
 # from wherever the gate activation is triggered. Note how sets can also be used within sets,
 # allowing you to compose more complex actions using simpler ones.
 
-let actions open_woodland_gate = {
+let actions OPEN_WOODLAND_GATE = {
     do add flag woodland-gate-open
     do modify room parish-landing {
         add exit "through the stargate" -> stargate-room
     }
 }
 
-let actions close_woodland_gate = {
+let actions CLOSE_WOODLAND_GATE = {
     do remove flag woodland-gate-open
     do modify room parish-landing {
         remove exit stargate-room
     }
 }
 
-let actions open_snowfield_gate = {
+let actions OPEN_SNOWFIELD_GATE = {
     do add flag snowfield-gate-open
     do modify room ice-pit {
         add exit "through the stargate" -> stargate-room
     }
 }
 
-let actions close_snowfield_gate = {
+let actions CLOSE_SNOWFIELD_GATE = {
     do remove flag snowfield-gate-open
     do modify room ice-pit {
         remove exit stargate-room
     }
 }
 
-let actions open_patio_gate = {
+let actions OPEN_PATIO_GATE = {
     do add flag patio-gate-open
     do modify room patio {
         add exit "through the stargate" -> stargate-room
     }
 }
 
-let actions close_patio_gate = {
+let actions CLOSE_PATIO_GATE = {
     do remove flag patio-gate-open
     do modify room patio {
         remove exit stargate-room
     }
 }
 
-let actions connect_woodland_stargate = {
+let actions OPEN_SECT_GATE = {
+    do add flag sect-gate-open
+    do modify room antechamber {
+        add exit "through the stargate" -> stargate-room
+    }
+}
+
+let actions CLOSE_SECT_GATE = {
+    do remove flag sect-gate-open
+    do modify room antechamber {
+        remove exit stargate-room
+    }
+}
+
+let actions CONNECT_SECT_STARGATE = {
+    # modify stargate room
+    do modify room stargate-room {
+        desc "A hangar-size concrete room, connected to the Aperture lab through a huge, round vault door. The Stargate is filled with a shimmering energy, from which you hear faint choir-like — [[i]]almost angelic[[/i]] — sound. Occasionally, you catch a whiff of leather. Or pumpkin?"
+        # add exit to antechamber and remove either of the others if previously opened
+        add exit "through the stargate" -> antechamber
+        remove exit ice-pit
+        remove exit patio
+        remove exit parish-landing
+    }
+
+    # modify receiving rooms and flags
+    run OPEN_SECT_GATE
+    run CLOSE_SNOWFIELD_GATE
+    run CLOSE_PATIO_GATE
+    run CLOSE_WOODLAND_GATE
+}
+let actions CONNECT_WOODLAND_STARGATE = {
     # modify stargate room
     do modify room stargate-room {
         desc "A hangar-size concrete room, connected to the Aperture lab through a huge, round vault door. The Stargate is filled with a shimmering energy, from which you hear whispering sound and birdsong. Occasionally, a bird flies out of the gate and circles it, but -- finding nowhere to land -- flies back in."
@@ -212,15 +282,17 @@ let actions connect_woodland_stargate = {
         add exit "through the stargate" -> parish-landing
         remove exit ice-pit
         remove exit patio
+        remove exit antechamber
     }
 
     # modify receiving rooms and flags
-    run open_woodland_gate
-    run close_snowfield_gate
-    run close_patio_gate
+    run OPEN_WOODLAND_GATE
+    run CLOSE_SNOWFIELD_GATE
+    run CLOSE_PATIO_GATE
+    run CLOSE_SECT_GATE
 }
 
-let actions connect_snowfield_stargate = {
+let actions CONNECT_SNOWFIELD_STARGATE = {
     # modify stargate room
     do modify room stargate-room {
         desc "A chilly, hangar-size concrete room, connected to the Aperture lab through a huge, round vault door. The Stargate is filled with a shimmering energy, from which you hear howling wind. Occasionally, another unearthly howl (Zomby Woof?) joins in."
@@ -228,15 +300,17 @@ let actions connect_snowfield_stargate = {
         add exit "through the stargate" -> ice-pit
         remove exit parish-landing
         remove exit patio
+        remove exit antechamber
     }
 
     # modify receiving rooms and flags
-    run open_snowfield_gate
-    run close_woodland_gate
-    run close_patio_gate
+    run OPEN_SNOWFIELD_GATE
+    run CLOSE_WOODLAND_GATE
+    run CLOSE_PATIO_GATE
+    run CLOSE_SECT_GATE
 }
 
-let actions connect_patio_stargate = {
+let actions CONNECT_PATIO_STARGATE = {
     # modify stargate room
     do modify room stargate-room {
         desc "A hangar-size concrete room, connected to the Aperture lab through a round vault door. The Stargate in the center is filled with a shimmering energy, from which you hear the sounds of clinking glasses punctuated by explosions. Occasionally, you catch a whiff of fresh baked bread in the air."
@@ -244,11 +318,13 @@ let actions connect_patio_stargate = {
         add exit "through the stargate" -> patio
         remove exit ice-pit
         remove exit parish-landing
+        remove exit antechamber
     }
     # modify receiving rooms and flags
-    run open_patio_gate
-    run close_woodland_gate
-    run close_snowfield_gate
+    run OPEN_PATIO_GATE
+    run CLOSE_WOODLAND_GATE
+    run CLOSE_SNOWFIELD_GATE
+    run CLOSE_SECT_GATE
 }
 
 # ========================================================================

--- a/amble_script/data/Amble/areas/bldg_perimeter/rooms/loading_dock.amble
+++ b/amble_script/data/Amble/areas/bldg_perimeter/rooms/loading_dock.amble
@@ -157,6 +157,8 @@ when act break on item security_locker {
         do spawn item initech_mug in current room
         do show "With a few hefty blows, you manage to break the lock haft completely off of the security locker -- well after a few misses had already caved in the lid and destroyed it, but you were having fun. It looks like you broke a couple of the items that were inside in the process."
         do add wedge "PA Announcement: 'Someone broke into the security locker on the dock. Mind your belongings and report any suspicious activity to security.'" width 1 spinner ambientInterior
+    } else {
+        do show "Despite already having unlocked the crate, you bash it a few times for emphasis."
     }
 }
 
@@ -170,6 +172,8 @@ when act burn on item security_locker {
         do spawn item initech_mug in current room
         do show "WHOOOOOMP! The locker, which you now realize may have been made from the solid magnesium magnolia trees of Siwenna, goes up in a white hot flash -- taking your eyebrows with it. It looks like *some* of the items inside weren't flammable."
         do add wedge "PA Announcement: 'Someone used an Arson-Aid to torch the security locker at the loading dock. An investigation is underway. Report anyone with scorched clothes or missing eyebrows to security.'" width 1 spinner ambientInterior
+    } else {
+        do show "Strange… it seems like this crate should burn easily, but somehow it doesn't."
     }
 }
 

--- a/amble_script/data/Amble/areas/snowfield/rooms/ice_pit.amble
+++ b/amble_script/data/Amble/areas/snowfield/rooms/ice_pit.amble
@@ -94,7 +94,7 @@ when use item plaque_2 ability read {
     do award points 10 reason "Read the frozen plaque"
     if has visited room stargate-room {
         do show "(A new Stargate destination has been enabled.)"
-        run connect_snowfield_stargate
+        run CONNECT_SNOWFIELD_STARGATE
     }
 }
 

--- a/amble_script/data/Amble/areas/woodland/rooms/parish_landing.amble
+++ b/amble_script/data/Amble/areas/woodland/rooms/parish_landing.amble
@@ -92,7 +92,7 @@ when use item plaque_1 ability read {
     }
     if all( has visited room stargate-room, has flag cleaned-plaque-1 ) {
         do show "(A new Stargate destination has been enabled.)"
-        run connect_woodland_stargate
+        run CONNECT_WOODLAND_STARGATE
     }
 }
 

--- a/amble_script/data/Amble/areas/woodland/rooms/parish_landing.amble
+++ b/amble_script/data/Amble/areas/woodland/rooms/parish_landing.amble
@@ -4,7 +4,7 @@
 
 room parish-landing {
     name "Parish Landing"
-    desc """A small plateau carved into the slope, marked by an old [[b]]wooden sign[[/b]] which reads:\n[[box:Candidates Welcome]][[b]]Pancakes Served Daily (Terms and Conditions Apply)[[/b]][[/box]]\nA faded poster nailed beside it shows a smiling Saint Alfonzo wielding a spatula like a holy relic. From here, the steps curve gently upward, disappearing into the woodland growth again. A modest, rutted trail leads west toward a nearby parish."""
+    desc """A small plateau carved into the slope, marked by an old [[b]]wooden sign[[/b]] which reads:\n[[box:Candidates Welcome]][[b]]Pancakes Served Daily (Terms and Conditions Apply)[[/b]][[/box]]\nA faded poster nailed beside it shows a smiling [[b]]Saint Alfonzo[[/b]] wielding a spatula like a holy relic. From here, the steps curve gently upward, disappearing into the woodland growth again. A modest, rutted trail leads west toward a nearby parish."""
 
     scenery "Saint Alfonzo" desc "The depiction looks suspiciously like Super Mario dressed in religious garb."
     scenery "Sculpted Pillar" desc "Ornate and hand-carved in rare marble that doesn't seem native to the area. The meticulous scrollwork and attention to detail expose the sculptor's deep reverence for the [[i]]wisdom imparted to those who read the plaque[[/i]]."

--- a/amble_script/data/Amble/dev_playground.amble
+++ b/amble_script/data/Amble/dev_playground.amble
@@ -47,8 +47,6 @@ item glow_stick {
     movability free
 }
 
-
-
 item pc {
     name "Linux Workstation"
     desc "A System76 laptop running Pop!_OS with COSMIC DE, with Zed open to a file called [[i]]dev_playground.amble[[/i]]."
@@ -116,16 +114,21 @@ when touch item big_red_button {
 trigger "Big Blue Button Pushed"
 note "test modify npc"
 when touch item big_blue_button {
-    do show "Modifying the Luggage..."
-    do modify npc the_luggage {
-        name "Hungry Luggage"
-        desc "The Luggage is ravenous! Beware!!"
-        state custom(hungry)
-        add line "(The Luggage nearly bites your face off when you approach.)" to state custom(hungry)
-        random rooms( dev-room, lounge )
-        timing every 5 turns
-        active true
-        loop true
+    if missing flag tried-the-blue-button {
+        do add flag tried-the-blue-button
+        do show "That will make the Luggage hungry. You might want to rethink that."
+    } else {
+        do show "Modifying the Luggage..."
+        do modify npc the_luggage {
+            name "Hungry Luggage"
+            desc "The Luggage is ravenous! Beware!!"
+            state custom(hungry)
+            add line "(The Luggage nearly bites your face off when you approach.)" to state custom(hungry)
+            random rooms( dev-room, lounge )
+            timing every 5 turns
+            active true
+            loop true
+        }
     }
 }
 

--- a/amble_script/data/Amble/global/anywhere_events.amble
+++ b/amble_script/data/Amble/global/anywhere_events.amble
@@ -66,11 +66,10 @@ trigger "[Global] Drop Vogon Poetry"
 note "dropping only stops the nausea if player has not read it"
 when drop item vogon_poetry_book
 {
-    if missing flag read-vogon-poetry {
-        do show "That greasy, queasy feeling subsides."
-    }
     if has flag read-vogon-poetry {
         do show "Getting rid of the book helps a little, but the poem is burned into your mind and the nausea continues."
+    } else {
+        do show "That greasy, queasy feeling quickly subsides."
     }
 }
 

--- a/amble_script/data/Amble/global/shoe_or_gourd.amble
+++ b/amble_script/data/Amble/global/shoe_or_gourd.amble
@@ -22,14 +22,14 @@ item messiah_kit {
 }
 
 item messiah_gourd {
-    name "Gourd"
+    name "The Messiah's Gourd"
     desc "A grapefruit-sized, tan gourd. It rattles a little when you shake it."
     movability free
     location chest messiah_kit
 }
 
 item messiah_shoe {
-    name "Shoe"
+    name "The Messiah's Shoe"
     desc "A single, worn leather sandal of untold age. [[i]]Something appears to be scratched into the sole.[[/i]]"
     movability free
     location chest messiah_kit
@@ -51,25 +51,48 @@ when open item messiah_kit {
 }
 
 let cond joined_any_sect = any( has flag sect-shoe, has flag sect-gourd )
+let cond no_sect_joined = all( missing flag sect-shoe, missing flag sect-gourd )
 
-trigger "Follower of the Shoe" only once
-note "locks player into the shoe sect"
-when take messiah_shoe from item messiah_kit {
-    do show "[[hl]]You are now a follower of the [[item]]Shoe[[/item]].[[/hl]]"
-    do set item movability messiah_gourd fixed "You are already a follower of the Shoe. Your faith in the Sanctified Sandal shall not be shaken."
-    do award points 5 reason "Became a Follower of the Shoe"
-    do add flag sect-shoe
-    do add wedge "Far above, the trees seem to whisper: \"Yesss. Yes! The Shoe is the Way.\" " width 1 spinner ambientWoodland
+let actions warn_player_about_sects = {
+    do show "[[bright-red]][[b]][[i]]…before fully taking it into your grasp, you have a moment of doubt…[[/i]][[/b]][[/bright-red]]"
+    do show "Is your faith [[u]]unshakable[[/u]]? Once you take either the [[item]]Shoe[[/item]] or the [[item]]Gourd[[/item]], there is no going back."
+    do add flag warned-about-sects
 }
 
-trigger "Follower of the Gourd" only once
+trigger "Follower of the Shoe"
+note "locks player into the shoe sect"
+when take messiah_shoe from item messiah_kit {
+    if missing flag warned-about-sects {
+        run warn_player_about_sects
+        do despawn item messiah_shoe
+        do spawn item messiah_shoe in container messiah_kit
+    } else {
+        if no_sect_joined {
+            do show "[[hl]]You are now a follower of the [[item]]Shoe[[/item]].[[/hl]]"
+            do set item movability messiah_gourd fixed "You are already a follower of the Shoe. Your faith in the Sanctified Sandal shall not be shaken."
+            do award points 5 reason "Became a Follower of the Shoe"
+            do add flag sect-shoe
+            do add wedge "Far above, the trees seem to whisper: \"Yesss. Yes! The Shoe is the Way.\" " width 1 spinner ambientWoodland
+        }
+    }
+}
+
+trigger "Follower of the Gourd"
 note "locks player into the gourd sect"
 when take messiah_gourd from item messiah_kit {
-    do show "[[b]]You are now a follower of the [[item]]Gourd[[/item]].[[/b]]"
-    do set item movability messiah_shoe fixed "You are already a follower of the Gourd. Your faith in the Vaunted Vegetable shall not be shaken."
-    do award points 5 reason "Became a Follower of the Gourd"
-    do add flag sect-gourd
-    do add wedge "Far above, the trees seem to whisper: \"Yesss. Yes! The Gourd is the Way.\" " width 1 spinner ambientWoodland
+    if missing flag warned-about-sects {
+        run warn_player_about_sects
+        do despawn item messiah_gourd
+        do spawn item messiah_gourd in container messiah_kit
+    } else {
+        if no_sect_joined {
+            do show "[[b]]You are now a follower of the [[item]]Gourd[[/item]].[[/b]]"
+            do set item movability messiah_shoe fixed "You are already a follower of the Gourd. Your faith in the Vaunted Vegetable shall not be shaken."
+            do award points 5 reason "Became a Follower of the Gourd"
+            do add flag sect-gourd
+            do add wedge "Far above, the trees seem to whisper: \"Yesss. Yes! The Gourd is the Way.\" " width 1 spinner ambientWoodland
+        }
+    }
 }
 
 #
@@ -195,6 +218,7 @@ item gourd_propaganda {
 
 item gourd_meeting_note {
     name "Gourder Meeting Memo"
+    aliases "handwritten note"
     visible when has flag sect-gourd
     desc "A handwritten memo to the [[i]][[b]]Followers of the Gourd[[/b]][[/i]] found tacked to the St. Alfonzo's sign."
     location room parish-landing

--- a/amble_script/docs/dsl_creator_handbook.md
+++ b/amble_script/docs/dsl_creator_handbook.md
@@ -118,7 +118,7 @@ when enter room lobby {
 
 - `note` is optional and copied into generated comments to help debugging.
 - `only once` prevents the trigger (and any lowered clones—see below) from firing more than a single time.
-- Each top-level `if { … }` block compiles into its own trigger entry; standalone `do …` lines outside of `if` become an unconditional variant.
+- Standalone top-level `if { … }` blocks still compile into their own trigger entry, but `if / else if / else` chains stay in-place as ordered conditional actions inside the trigger body.
 
 ### Events (`when …`)
 

--- a/amble_script/docs/trigger_dsl_guide.md
+++ b/amble_script/docs/trigger_dsl_guide.md
@@ -84,6 +84,18 @@ if radio_ready { … }
 if in rooms lobby,restaurant { … }
 ```
 
+Conditional branches may also include `else` clauses:
+
+```amble
+if has flag quest-started {
+  do show "The machine hums to life."
+} else if has item toolkit {
+  do show "You can probably fix this manually."
+} else {
+  do show "Nothing happens."
+}
+```
+
 ## Actions (`do …`)
 
 Player feedback and flags:
@@ -293,7 +305,8 @@ If you find yourself repeating a list of rooms for ambients, declare a `set` onc
 
 You can have multiple top‑level `if { … }` blocks in a single trigger, plus plain `do …` lines not wrapped by an `if`.
 
-- Each `if` block compiles to its own trigger sharing the same `when` event; it carries only that block’s conditions and actions.
+- A standalone top-level `if { … }` block with no `else` compiles to its own trigger sharing the same `when` event; it carries only that block’s conditions and actions.
+- An `if / else if / else` chain stays inside the trigger body as an ordered conditional action, so only the first matching branch runs.
 - Plain `do …` lines outside any `if` compile to an additional unconditional trigger for the same event.
 - If several blocks’ conditions are true on the same turn, each corresponding trigger can fire.
 - `only once` applies to all triggers produced from the parent.
@@ -308,4 +321,4 @@ trigger "Arrival" when enter room lab {
 }
 ```
 
-Compiles to three triggers with the same name and event: one for each `if` and one unconditional.
+Compiles to three triggers with the same name and event: one for each standalone `if` and one unconditional.

--- a/amble_script/src/grammar.pest
+++ b/amble_script/src/grammar.pest
@@ -211,12 +211,12 @@ ingest_mode      = { "eat" | "drink" | "inhale" }
 
 block = { "{" ~ stmt_block ~ "}" }
 
-// Allow multiple if-blocks and/or plain do statements at top-level
-stmt_block = { (if_block | do_stmt | run_stmt)+ }
-
-if_block = { "if" ~ cond ~ block_inner }
-
-block_inner = { "{" ~ (do_stmt | run_stmt)+ ~ "}" }
+// Allow nested if/else statements as well as plain do/run statements.
+stmt_block = { stmt_item+ }
+stmt_item = { if_block | do_stmt | run_stmt }
+if_block = { "if" ~ cond ~ block_inner ~ else_clause? }
+else_clause = { "else" ~ (if_block | block_inner) }
+block_inner = { "{" ~ stmt_item+ ~ "}" }
 
 priority_clause = { "priority" ~ number }
 do_stmt         = { "do" ~ priority_clause? ~ do_action }

--- a/amble_script/src/lib.rs
+++ b/amble_script/src/lib.rs
@@ -469,6 +469,7 @@ pub enum ActionAst {
     Conditional {
         condition: Box<ConditionAst>,
         actions: Vec<ActionStmt>,
+        false_actions: Option<Vec<ActionStmt>>,
     },
 }
 

--- a/amble_script/src/main.rs
+++ b/amble_script/src/main.rs
@@ -1077,8 +1077,15 @@ fn collect_flags_from_action_defs(actions: &[amble_data::ActionDef], out: &mut H
             amble_data::ActionKind::AddFlag { flag } => {
                 out.insert(flag_name(flag));
             },
-            amble_data::ActionKind::Conditional { actions, .. }
-            | amble_data::ActionKind::ScheduleIn { actions, .. }
+            amble_data::ActionKind::Conditional {
+                actions, false_actions, ..
+            } => {
+                collect_flags_from_action_defs(actions, out);
+                if let Some(false_actions) = false_actions {
+                    collect_flags_from_action_defs(false_actions, out);
+                }
+            },
+            amble_data::ActionKind::ScheduleIn { actions, .. }
             | amble_data::ActionKind::ScheduleOn { actions, .. }
             | amble_data::ActionKind::ScheduleInIf { actions, .. }
             | amble_data::ActionKind::ScheduleOnIf { actions, .. } => {

--- a/amble_script/src/parser/actions.rs
+++ b/amble_script/src/parser/actions.rs
@@ -767,7 +767,7 @@ fn skip_ws_and_comments(body: &str, mut i: usize) -> usize {
     i
 }
 
-fn parse_if_action(
+pub(super) fn parse_if_action(
     body: &str,
     start: usize,
     source: &str,
@@ -793,12 +793,36 @@ fn parse_if_action(
     let block_after = &rest[brace_rel..];
     let inner_body = extract_body(block_after)?;
     let actions = parse_actions_from_body(inner_body, source, smap, sets, aliases, resolve_action_set)?;
+    let mut new_i = if_pos + 3 + brace_rel + 1 + inner_body.len() + 1;
+    let mut false_actions = None;
+    let after_if = skip_ws_and_comments(body, new_i);
+    if let Some(after_else_kw) = body[after_if..].strip_prefix("else").map(|_| after_if + 4) {
+        let after_else = skip_ws_and_comments(body, after_else_kw);
+        if let Some((else_if, else_end)) =
+            parse_if_action(body, after_else, source, smap, sets, aliases, resolve_action_set)?
+        {
+            false_actions = Some(vec![else_if]);
+            new_i = else_end;
+        } else if body[after_else..].starts_with('{') {
+            let else_body = extract_body(&body[after_else..])?;
+            false_actions = Some(parse_actions_from_body(
+                else_body,
+                source,
+                smap,
+                sets,
+                aliases,
+                resolve_action_set,
+            )?);
+            new_i = after_else + 1 + else_body.len() + 1;
+        } else {
+            return Err(AstError::Shape("missing '{' or 'if' after else"));
+        }
+    }
     let action = ActionStmt::new(ActionAst::Conditional {
         condition: Box::new(cond),
         actions,
+        false_actions,
     });
-    let consumed = brace_rel + 1 + inner_body.len() + 1;
-    let new_i = if_pos + 3 + consumed;
     Ok(Some((action, new_i)))
 }
 

--- a/amble_script/src/parser/mod.rs
+++ b/amble_script/src/parser/mod.rs
@@ -1123,12 +1123,127 @@ trigger "Radio Hint" when always {
         assert_eq!(triggers.len(), 1);
         assert_eq!(triggers[0].actions.len(), 1);
         match &triggers[0].actions[0].action {
-            ActionAst::Conditional { condition, actions } => {
+            ActionAst::Conditional {
+                condition,
+                actions,
+                false_actions,
+            } => {
                 assert_eq!(**condition, ConditionAst::HasFlag("radio-on".into()));
                 assert_eq!(
                     actions,
                     &vec![ActionStmt::new(ActionAst::AddFlag("nested-ready".into()))]
                 );
+                assert_eq!(false_actions, &None);
+            },
+            other => panic!("expected conditional action, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn top_level_if_without_else_still_lowers_to_separate_trigger() {
+        let src = r#"
+trigger "Radio Hint" when always {
+  if has flag radio-on {
+    do show "Ready."
+  }
+  do add flag radio-ready
+}
+"#;
+        let (_game, triggers, ..) = parse_program_full(src).expect("top-level if parse succeeds");
+
+        assert_eq!(triggers.len(), 2);
+        assert_eq!(triggers[0].conditions, vec![ConditionAst::HasFlag("radio-on".into())]);
+        assert_eq!(
+            triggers[0].actions,
+            vec![ActionStmt::new(ActionAst::Show("Ready.".into()))]
+        );
+        assert!(triggers[1].conditions.is_empty());
+        assert_eq!(
+            triggers[1].actions,
+            vec![ActionStmt::new(ActionAst::AddFlag("radio-ready".into()))]
+        );
+    }
+
+    #[test]
+    fn top_level_if_else_lowers_to_runtime_conditional_action() {
+        let src = r#"
+trigger "Radio Hint" when always {
+  if has flag radio-on {
+    do show "Ready."
+  } else {
+    do show "Not ready."
+  }
+}
+"#;
+        let (_game, triggers, ..) = parse_program_full(src).expect("top-level if-else parse succeeds");
+
+        assert_eq!(triggers.len(), 1);
+        assert!(triggers[0].conditions.is_empty());
+        assert_eq!(triggers[0].actions.len(), 1);
+        match &triggers[0].actions[0].action {
+            ActionAst::Conditional {
+                condition,
+                actions,
+                false_actions,
+            } => {
+                assert_eq!(**condition, ConditionAst::HasFlag("radio-on".into()));
+                assert_eq!(actions, &vec![ActionStmt::new(ActionAst::Show("Ready.".into()))]);
+                assert_eq!(
+                    false_actions,
+                    &Some(vec![ActionStmt::new(ActionAst::Show("Not ready.".into()))])
+                );
+            },
+            other => panic!("expected conditional action, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_else_if_chain_parses_as_recursive_conditional_actions() {
+        let src = r#"
+let actions outer_steps = {
+  if has flag radio-on {
+    do add flag first-path
+  } else if has item hint_radio {
+    do add flag second-path
+  } else {
+    do add flag third-path
+  }
+}
+
+trigger "Radio Hint" when always {
+  run outer_steps
+}
+"#;
+        let (_game, triggers, ..) = parse_program_full(src).expect("nested else-if parse succeeds");
+
+        assert_eq!(triggers.len(), 1);
+        match &triggers[0].actions[0].action {
+            ActionAst::Conditional {
+                condition,
+                actions,
+                false_actions: Some(false_actions),
+            } => {
+                assert_eq!(**condition, ConditionAst::HasFlag("radio-on".into()));
+                assert_eq!(actions, &vec![ActionStmt::new(ActionAst::AddFlag("first-path".into()))]);
+                assert_eq!(false_actions.len(), 1);
+                match &false_actions[0].action {
+                    ActionAst::Conditional {
+                        condition,
+                        actions,
+                        false_actions: Some(false_actions),
+                    } => {
+                        assert_eq!(**condition, ConditionAst::HasItem("hint_radio".into()));
+                        assert_eq!(
+                            actions,
+                            &vec![ActionStmt::new(ActionAst::AddFlag("second-path".into()))]
+                        );
+                        assert_eq!(
+                            false_actions,
+                            &vec![ActionStmt::new(ActionAst::AddFlag("third-path".into()))]
+                        );
+                    },
+                    other => panic!("expected nested conditional action, got {other:?}"),
+                }
             },
             other => panic!("expected conditional action, got {other:?}"),
         }

--- a/amble_script/src/parser/trigger.rs
+++ b/amble_script/src/parser/trigger.rs
@@ -4,10 +4,9 @@ use std::collections::HashMap;
 use crate::{ActionStmt, ConditionAst, IngestModeAst, TriggerAst};
 
 use super::actions::{
-    parse_action_from_str, parse_actions_from_body, parse_modify_item_action, parse_modify_npc_action,
+    parse_action_from_str, parse_if_action, parse_modify_item_action, parse_modify_npc_action,
     parse_modify_room_action, parse_schedule_action,
 };
-use super::conditions::parse_condition_text;
 use super::helpers::{SourceMap, extract_body, is_ident_char, str_offset, unquote};
 use super::{AstError, DslParser, Rule};
 
@@ -272,46 +271,28 @@ pub(super) fn parse_trigger_pair(
             }
             continue;
         }
-        // If-block
-        if inner[i..].starts_with("if ") {
-            let if_pos = i;
-            // Find opening brace
-            let rest = &inner[if_pos + 3..];
-            let brace_rel = rest.find('{').ok_or(AstError::Shape("missing '{' after if"))?;
-            let cond_text = &rest[..brace_rel].trim();
-            let cond = match parse_condition_text(cond_text, sets, aliases) {
-                Ok(c) => c,
-                Err(AstError::Shape(m)) => {
-                    let base_offset = str_offset(source, inner);
-                    let cond_abs = base_offset + (cond_text.as_ptr() as usize - inner.as_ptr() as usize);
-                    let (line, col) = smap.line_col(cond_abs);
-                    let snippet = smap.line_snippet(line);
-                    return Err(AstError::ShapeAt {
-                        msg: m,
-                        context: format!(
-                            "line {line}, col {col}: {snippet}\n{}^",
-                            " ".repeat(col.saturating_sub(1))
-                        ),
-                    });
-                },
-                Err(e) => return Err(e),
-            };
-            // Extract the block body after this '{' balancing braces
-            let block_after = &rest[brace_rel..]; // starts with '{'
-            let body = extract_body(block_after)?;
-            let actions = parse_actions_from_body(body, source, smap, sets, aliases, &mut resolve_action_set)?;
-            lowered.push(TriggerAst {
-                name: name.clone(),
-                note: None,
-                src_line,
-                event: event.clone(),
-                conditions: vec![cond],
-                actions,
-                only_once,
-            });
-            // Advance i to after the block we just consumed
-            let consumed = brace_rel + 1 + body.len() + 1; // '{' + body + '}'
-            i = if_pos + 3 + consumed;
+        if let Some((action, new_i)) = parse_if_action(inner, i, source, smap, sets, aliases, &mut resolve_action_set)?
+        {
+            match action.action {
+                crate::ActionAst::Conditional {
+                    condition,
+                    actions,
+                    false_actions: None,
+                } => lowered.push(TriggerAst {
+                    name: name.clone(),
+                    note: None,
+                    src_line,
+                    event: event.clone(),
+                    conditions: vec![*condition],
+                    actions,
+                    only_once,
+                }),
+                other => unconditional_actions.push(ActionStmt {
+                    priority: action.priority,
+                    action: other,
+                }),
+            }
+            i = new_i;
             continue;
         }
         let remainder = &inner[i..];

--- a/amble_script/src/worlddef.rs
+++ b/amble_script/src/worlddef.rs
@@ -561,9 +561,17 @@ fn action_to_kind(action: &ActionAst) -> Result<ActionKind, WorldDefError> {
             actions: actions_to_defs(actions)?,
             note: note.clone(),
         },
-        ActionAst::Conditional { condition, actions } => ActionKind::Conditional {
+        ActionAst::Conditional {
+            condition,
+            actions,
+            false_actions,
+        } => ActionKind::Conditional {
             condition: condition_expr_from_ast(condition)?,
             actions: actions_to_defs(actions)?,
+            false_actions: false_actions
+                .as_ref()
+                .map(|actions| actions_to_defs(actions))
+                .transpose()?,
         },
     })
 }


### PR DESCRIPTION
### Else and Else If

This patch adds "else" and chained "else if" clauses within trigger bodies.

```
trigger "Big Blue Button Pushed"
note "test modify npc"
when touch item big_blue_button {
    if missing flag tried-the-blue-button {
        do add flag tried-the-blue-button
        do show "That will make the Luggage hungry. You might want to rethink that."
    } else {
        do show "Modifying the Luggage..."
        do modify npc the_luggage {
            name "Hungry Luggage"
            desc "The Luggage is ravenous! Beware!!"
            state custom(hungry)
            add line "(The Luggage nearly bites your face off when you approach.)" to state custom(hungry)
            random rooms( dev-room, lounge )
            timing every 5 turns
            active true
            loop true
        }
    }
}
```

Similar effects could be attained in convoluted ways prior to the addition of else clauses through flags and additional triggers, but the seemingly minor addition of "else" simplifies logic and shrinks the number of triggers and by extension the size of world.ron files. 

**Else and else if** added to DSL grammar and compiler. 
Demo game *.amble files updated where appropriate to use "else" clauses.

Cargo test --all green.
Manual playtest through first 5-6 locations of Amble Adventure demo all working normally.
